### PR TITLE
2.1.4 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,12 @@ Release date: 2020-01-12
 ### Enhancements
 
 * You can now specify fields to fetch in addition to the fields defined in a
-  saved-query.
+  saved-query. References:
+  * [Common Options for get-by-saved-query](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.html#fr-214-5)
 * You can now specify fields using regular expressions whereever fields can
   be specified.
+  * [Select Fields: Using Regular Expressions Case 1](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/common_examples/select_field_examples/ex7.html#fr-214-3)
+  * [Select Fields: Using Regular Expressions Case 2](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/common_examples/select_field_examples/ex8.html#fr-214-4)
 * You can use show-config when adding new connections to see the configuration without
   being prompted.
+  * [Show the settings needed for a connection in text format](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.html#fr-214-1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,20 @@
+# Release notes
+
+## 2.1.4
+
+Release date: 2020-01-12
+
+### Bug fixes
+
+* Fixed a minor issue with text string 'False' not being recognized as
+  an alternative for boolean False.
+* Fixed a minor issue with selecting an adapter connection by ID.
+
+### Enhancements
+
+* You can now specify fields to fetch in addition to the fields defined in a
+  saved-query.
+* You can now specify fields using regular expressions whereever fields can
+  be specified.
+* You can use show-config when adding new connections to see the configuration without
+  being prompted.

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ pyenv_init:
 
 lint:
 	pipenv run isort -rc -y $(PACKAGE) setup.py axonshell*.py
-	pipenv run pipenv run black $(PACKAGE) setup.py axonshell*.py
-	pipenv run pydocstyle $(PACKAGE) setup.py axonshell*.py
+	pipenv run pipenv run black -l 89 $(PACKAGE) setup.py axonshell*.py
+	pipenv run pydocstyle --match='(?!test_).*\.py' $(PACKAGE) setup.py axonshell*.py
 	pipenv run flake8 --max-line-length 89 $(PACKAGE) setup.py axonshell*.py
 	pipenv run bandit --skip B101 -r $(PACKAGE)
 
 test:
-	pipenv run pytest -ra --verbose --junitxml=junit-report.xml --cov-config=.coveragerc --cov-report xml --cov-report=html:cov_html --cov=$(PACKAGE) --showlocals  --exitfirst $(PACKAGE)/tests
+	pipenv run pytest -ra --verbose --cov-config=.coveragerc --cov-report xml --cov-report=html:cov_html --cov=$(PACKAGE) --showlocals  --exitfirst $(PACKAGE)/tests
 
 test_dev:
 	pipenv run pytest -vv --showlocals --exitfirst --last-failed $(PACKAGE)/tests

--- a/TODO.md
+++ b/TODO.md
@@ -1,25 +1,5 @@
 # API client todos
 
-## 2.1.4
-
-### Add support for fields + sq fields in SQ get
-
-DONE, ADD EXAMPLES TO DOCS
-
-### add --show-config to cnx add
-
-DONE, ADD EXAMPLES TO DOCS
-
-### users_devices.py:Fields.find: add ability to specify fields using regex
-
-DONE, ADD EXAMPLES TO DOCS
-
-### Add client side cert support
-
-DONE, ADD EXAMPLES TO DOCS
-
-### Add export format: SQL dump
-
 ## DOCS
 
 ### need to doc proxy and cert
@@ -79,6 +59,8 @@ axonshell devices get \
     --field-flatten installed_software
 ```
 
+### Add export format: SQL dump
+
 ### Add export format: word
 
 Would need to add optional package requirements.
@@ -117,13 +99,13 @@ Just like GUI. GUI processes it client side, so we have to do the same.
 Concept:
 
 ```text
-    --field-filter-eq "installed_software.name=Google Chrome||Google Chrome Installer"
-    --field-filter-re "installed_software.name=.*google.*"
-    --field-filter-in "installed_software.name=google"
-    --field-filter-lt "installed_software.version=77"
-    --field-filter-lte
-    --field-filter-gt
-    --field-filter-gte
+    --field-filter "eq:installed_software.name=Google Chrome||Google Chrome Installer"
+    --field-filter "re:installed_software.name=.*google.*"
+    --field-filter "in:installed_software.name=google"
+    --field-filter "not:eq:installed_software.version=77"
+    --field-filter "lte:2:installed_software.name"
+    --field-filter "gt:2"
+    --field-filter "gte:2"
 ```
 
 ### users_devices.py:UserDeviceMixin.get: Add logging for page rows fetched
@@ -152,9 +134,9 @@ This may no longer be necessary? Re-check.
 Concept:
 
 ```text
---field-weight hostname:aws=10,bluecat=1
+--field-weight hostname:aws=10,sccm=10,solwarinds=10,jamf=9,ad=9,bluecat=1
 # (score aws as the heaviest)
-
+weighted.hostname
 ```
 
 #### User to Device correlation
@@ -270,30 +252,6 @@ be empty for that SQ due to no expressions. This would possibly mean moving
 query wizard parsing from front end JS to API?
 
 ### Enforcements API needs love
-
-### create SQ with two underscores in name fails
-
-Works:
-
-```text
-z=users.saved_query._add(
-        name='badwolf_test_add_get_delete',
-        query='(internal_axon_id == "f7895a5487d6eda9b2d6573680159a7c")',
-        fields=["specific_data.data.username"]
-)
-```
-
-Doesn't:
-
-```text
-z=users.saved_query._add(
-    name='badwolf_test__add_get_delete',
-    query='(internal_axon_id == "f7895a5487d6eda9b2d6573680159a7c")',
-    fields=["specific_data.data.username"]
-)
-```
-
-TestSavedQuery.test__add_get_delete[Users] still failing. wtf
 
 ### Add lifecycle from private API to public API
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,8 +16,9 @@ DONE, ADD EXAMPLES TO DOCS
 
 ### Add client side cert support
 
-For mutual TLS. AX-5789 & PROD-797
-NEED TESTS
+DONE, ADD EXAMPLES TO DOCS
+
+### Add export format: SQL dump
 
 ## DOCS
 
@@ -77,8 +78,6 @@ axonshell devices get \
     -f installed_software.name \
     --field-flatten installed_software
 ```
-
-### Add export format: SQL dump
 
 ### Add export format: word
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,36 @@
 # API client todos
 
-## NOW
+## 2.1.4
 
-axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py:
-stalling, figure out why
+### add --show-config to cnx add
 
-axonius_api_client/tests/tests_api/test_api_users_devices.py:
-4 F's, figure out why
+ADD TEST & DOC
+
+### users_devices.py:Fields.find: add ability to specify fields using regex
+
+generic:hostname
+or hostname
+or tanium:hostname, crowdstrike:hostname
+
+```text
+
+general
+generic
+all
+*
+
+*:hostname
+*:*host*
+
+```
+
+### Add client side cert support
+
+For mutual TLS. AX-5789 & PROD-797
+
+### Filter by client id for cnx not working
+
+fix it
 
 ## DOCS
 
@@ -93,10 +117,6 @@ In adapters cnx add. Maybe custom click type?
 
 ## HTTP package
 
-### Add client side cert support
-
-For mutual TLS. AX-5789 & PROD-797
-
 ## API package
 
 ## enforcements.py: Needs work, awaiting REST API updates
@@ -124,8 +144,6 @@ Concept:
 
 This may no longer be necessary? Re-check.
 
-### users_devices.py:Fields.find: add ability to specify fields using regex
-
 ### users_devices.py:Reports: new reports
 
 #### Majority rule concept
@@ -150,6 +168,7 @@ Concept:
 ```text
 --field-weight hostname:aws=10,bluecat=1
 # (score aws as the heaviest)
+
 ```
 
 #### User to Device correlation
@@ -200,6 +219,12 @@ Currently only stored in:
 ```text
 cortex/plugins/gui/frontend/src/constants/plugin_meta.js
 ```
+
+### Add support for user add/delete/modify
+
+### Add support for lifecycle endpoint
+
+### Add support for discover phase
 
 ### add support for setting advanced settings
 
@@ -259,3 +284,31 @@ be empty for that SQ due to no expressions. This would possibly mean moving
 query wizard parsing from front end JS to API?
 
 ### Enforcements API needs love
+
+### create SQ with two underscores in name fails
+
+Works:
+
+```text
+z=users.saved_query._add(
+        name='badwolf_test_add_get_delete',
+        query='(internal_axon_id == "f7895a5487d6eda9b2d6573680159a7c")',
+        fields=["specific_data.data.username"]
+)
+```
+
+Doesn't:
+
+```text
+z=users.saved_query._add(
+    name='badwolf_test__add_get_delete',
+    query='(internal_axon_id == "f7895a5487d6eda9b2d6573680159a7c")',
+    fields=["specific_data.data.username"]
+)
+```
+
+TestSavedQuery.test__add_get_delete[Users] still failing. wtf
+
+### Add lifecycle from private API to public API
+
+Allow for conditional "stuffs"

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@
 
 ### need to doc proxy and cert
 
+### All docstrings re-done
+
 ## CLI package
 
 ### Add flatten option for export

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 ### add --show-config to cnx add
 
-ADD TEST & DOC
+ADD DOC
 
 ### users_devices.py:Fields.find: add ability to specify fields using regex
 
@@ -27,10 +27,6 @@ all
 ### Add client side cert support
 
 For mutual TLS. AX-5789 & PROD-797
-
-### Filter by client id for cnx not working
-
-fix it
 
 ## DOCS
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,208 @@
+# API client todos
+
+## DOCS
+
+### need to doc proxy and cert
+
+## CLI package
+
+### Add flatten option for export
+
+- external method, called by to_json & to_csv
+- have to figure out how to handle multiple fields to flatten
+- need to verify field actually supplied??
+
+Concept:
+
+```text
+
+This:
+|| h || swname || swver ||
+|| xxx|| abc, def, ghi || 1,2,3 ||
+
+becomes:
+
+|| h || swname || swver ||
+|| xxx|| abc || 1 ||
+|| xxx|| def || 2 ||
+|| xxx|| ghi || 3 ||
+
+axonshell devices get \
+    -q (specific_data.data.last_seen >= date("NOW - 30d")) \
+    -f installed_software.name \
+    --field-flatten installed_software
+```
+
+### Add export format: SQL dump
+
+### Add export format: word
+
+Would need to add optional package requirements.
+
+### Add export format: pdf
+
+Would need to add optional package requirements.
+
+### Accept ini based config
+
+In adapters cnx add. Unsure of this.
+
+### Determine better way handle skips in prompts
+
+In adapters cnx add. Maybe custom click type?
+
+### Add --verbose/--no-verbose to silence echo_ok
+
+### Add cert_human logic
+
+### Add links to docs site in --help
+
+## HTTP package
+
+### Add client side cert support
+
+For mutual TLS. AX-5789 & PROD-797
+
+## API package
+
+### users_devices.py:UserDeviceMixin.get_by_saved_query: Need filters
+
+Just like GUI. GUI processes it client side, so we have to do the same.
+
+Concept:
+
+```text
+    --field-filter-eq "installed_software.name=Google Chrome||Google Chrome Installer"
+    --field-filter-re "installed_software.name=.*google.*"
+    --field-filter-in "installed_software.name=google"
+    --field-filter-lt "installed_software.version=77"
+    --field-filter-lte
+    --field-filter-gt
+    --field-filter-gte
+```
+
+### users_devices.py:UserDeviceMixin.get: Add logging for page rows fetched
+
+This may no longer be necessary? Re-check.
+
+### users_devices.py:Fields.find: add ability to specify fields using regex
+
+### users_devices.py:Reports: new reports
+
+#### Majority rule concept
+
+- for a general field, say hostname
+- get the values of hostname from ALL adapters in system
+- find the value that is the MOST common value and add that as a value for a
+  key majority_hostname
+
+#### Weighting concept
+
+- for a general field, say hostname
+- get the values of hostname from ALL adapters in system
+- allow weighting on a 1-10 score
+- if adapter x with a score of 10 has hostname1, add that as a value for a key
+  weighted_hostname
+- if adapter x with a score of 10 has NO hostname, fallback to adapter y with a score
+  of 7
+
+Concept:
+
+```text
+--field-weight hostname:aws=10,bluecat=1
+# (score aws as the heaviest)
+```
+
+#### User to Device correlation
+
+- for each user
+  - for each device
+    find any users whose username matches last logged in user
+    device[users] = found_users
+
+#### Missing patches
+
+Concept:
+
+```text
+axonshell devices get | axonshell devices get-missing-patches --patch KB293028424
+```
+
+#### Count of assets with matching installed_software.name values
+
+Identify source of request, need more details.
+
+#### Missing software
+
+Similar to missing patches.
+
+### users_devices.py:Reports.missing_adapters: show per node missing columns
+
+Right now shows all nodes grouped
+
+## REST API
+
+### Add adapter description to adapter metadata
+
+Currently only stored in:
+
+```text
+cortex/plugins/gui/frontend/src/constants/plugin_meta.js
+```
+
+### add support for setting advanced settings
+
+General adapter advanced settings:
+
+```text
+method=POST
+path=/api/plugins/configs/carbonblack_defense_adapter/AdapterBase
+body={
+    "connect_client_timeout": 300,
+    "fetching_timeout": 5400,
+    "last_fetched_threshold_hours": 49,
+    "last_seen_prioritized": false,
+    "last_seen_threshold_hours": 43800,
+    "minimum_time_until_next_fetch": null,
+    "realtime_adapter": false,
+    "user_last_fetched_threshold_hours": null,
+    "user_last_seen_threshold_hours": null
+}
+```
+
+Adapter specific advanced settings:
+
+```text
+method=POST
+path=/api/plugins/configs/carbonblack_defense_adapter/CarbonblackDefenseAdapter
+body={"fetch_deregistred":false}
+```
+
+### Modify date_fetched for adapter connection
+
+Make it be last time any fetch happened
+
+Currently it seems to be only for when fetch has been triggered
+from "save" in adapters>connection page, and does not include when
+last fetch happened from discover.
+
+Pcode for determining last fetch:
+
+```text
+date_fetched = client["date_fetched"]
+minutes_ago = tools.dt.minutes_ago(date_fetched)
+
+if within is not None:
+    if minutes_ago >= within:
+        continue
+
+if not_within is not None:
+    if minutes_ago <= not_within:
+        continue
+```
+
+### Process saved query expressions on add if none supplied
+
+Currently, if you add a SQ via API without expressions, the query wizard will
+be empty for that SQ due to no expressions. This would possibly mean moving
+query wizard parsing from front end JS to API?

--- a/TODO.md
+++ b/TODO.md
@@ -2,27 +2,17 @@
 
 ## 2.1.4
 
+### Add support for fields + sq fields in SQ get
+
+DONE, ADD EXAMPLES TO DOCS
+
 ### add --show-config to cnx add
 
-ADD DOC
+DONE, ADD EXAMPLES TO DOCS
 
 ### users_devices.py:Fields.find: add ability to specify fields using regex
 
-generic:hostname
-or hostname
-or tanium:hostname, crowdstrike:hostname
-
-```text
-
-general
-generic
-all
-*
-
-*:hostname
-*:*host*
-
-```
+DONE, ADD EXAMPLES TO DOCS
 
 ### Add client side cert support
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@ DONE, ADD EXAMPLES TO DOCS
 ### Add client side cert support
 
 For mutual TLS. AX-5789 & PROD-797
+NEED TESTS
 
 ## DOCS
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,42 @@
 # API client todos
 
+## NOW
+
+axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py:
+stalling, figure out why
+
+axonius_api_client/tests/tests_api/test_api_users_devices.py:
+4 F's, figure out why
+
 ## DOCS
 
 ### need to doc proxy and cert
 
 ### All docstrings re-done
+
+## Tests package
+
+### Make client config automatically determine adapter config
+
+Solve for changing schemas.
+
+### Test subclassing/strings/etc of all exceptions
+
+In tests_pkg/test_exceptions.py
+
+### add atexit to verify no badwolf leftovers
+
+Actions leftover, need to determine how to clean up
+
+### Permissions check not the same octal on windows
+
+In tests_pkg/test_tools.py:test_simple_pathlib
+
+### SQ keys unknown value unknown
+
+in tests_api/test_api_users_devices.py:TestSavedQuery.test__get
+
+"historical" and "filteredAdapters" in expressions
 
 ## CLI package
 
@@ -66,6 +98,11 @@ In adapters cnx add. Maybe custom click type?
 For mutual TLS. AX-5789 & PROD-797
 
 ## API package
+
+## enforcements.py: Needs work, awaiting REST API updates
+
+Will need something like a public build_trigger method
+public create will need to get sq!
 
 ### users_devices.py:UserDeviceMixin.get_by_saved_query: Need filters
 
@@ -144,6 +181,18 @@ Right now shows all nodes grouped
 
 ## REST API
 
+### Schema's are defining required items that dont exist in items
+
+In tests_api/test_api_adapters.py
+
+### Some connection configs have empty client ID's
+
+In tests_api/test_api_adapters.py
+
+### adding cnx with parsed config instead of raw config breaks stuff
+
+check if this is fixed.
+
 ### Add adapter description to adapter metadata
 
 Currently only stored in:
@@ -208,3 +257,5 @@ if not_within is not None:
 Currently, if you add a SQ via API without expressions, the query wizard will
 be empty for that SQ due to no expressions. This would possibly mean moving
 query wizard parsing from front end JS to API?
+
+### Enforcements API needs love

--- a/axonius_api_client/api/adapters.py
+++ b/axonius_api_client/api/adapters.py
@@ -317,9 +317,7 @@ class Adapters(mixins.Model, mixins.Mixins):
 
         return matches
 
-    def filter_by_status(
-        self, adapters, value=None, match_count=None, match_error=True
-    ):
+    def filter_by_status(self, adapters, value=None, match_count=None, match_error=True):
         """Filter adapters with matching statuses.
 
         Args:
@@ -974,9 +972,7 @@ class Cnx(mixins.Child):
         if had_error:
             if warning and not error:
                 warnings.warn(
-                    exceptions.CnxDeleteFailedWarning(
-                        cnxinfo=cnxinfo, response=response
-                    )
+                    exceptions.CnxDeleteFailedWarning(cnxinfo=cnxinfo, response=response)
                 )
             elif error:
                 raise exceptions.CnxDeleteFailed(cnxinfo=cnxinfo, response=response)
@@ -1821,51 +1817,3 @@ def validate_csv(name, content, is_users=False, is_installed_sw=False):
                 ids_type=ids_type, ids=ids, name=name, headers=headers
             )
         )
-
-
-# REST API FR: public REST API does not support setting advanced settings
-"""
-# advanced settings
-method=POST
-path=/api/plugins/configs/carbonblack_defense_adapter/AdapterBase
-body=
-{
-    "connect_client_timeout": 300,
-    "fetching_timeout": 5400,
-    "last_fetched_threshold_hours": 49,
-    "last_seen_prioritized": false,
-    "last_seen_threshold_hours": 43800,
-    "minimum_time_until_next_fetch": null,
-    "realtime_adapter": false,
-    "user_last_fetched_threshold_hours": null,
-    "user_last_seen_threshold_hours": null
-}
-"""
-
-"""
-# adapter specific advanced settings
-method=POST
-path=/api/plugins/configs/carbonblack_defense_adapter/CarbonblackDefenseAdapter
-body={"fetch_deregistred":false}
-"""
-
-"""
-# rule to add to api.py
-@api_add_rule('plugins/configs/<plugin_name>/<config_name>', methods=['POST', 'GET'],
-    wrap around service.py: plugins_configs_set()
-"""
-
-# REST API FR: date_fetched for client seems to be only for
-# when fetch has been triggered from "save" in adapters>client page??
-"""
-date_fetched = client["date_fetched"]
-minutes_ago = tools.dt.minutes_ago(date_fetched)
-
-if within is not None:
-    if minutes_ago >= within:
-        continue
-
-if not_within is not None:
-    if minutes_ago <= not_within:
-        continue
-"""

--- a/axonius_api_client/api/mixins.py
+++ b/axonius_api_client/api/mixins.py
@@ -43,7 +43,7 @@ class Mixins(object):
     """API client for Axonius REST API."""
 
     def __init__(self, auth, **kwargs):
-        """Constructor.
+        """Client for Axonius REST API.
 
         Args:
             auth (:obj:`AuthModel`):

--- a/axonius_api_client/api/routers.py
+++ b/axonius_api_client/api/routers.py
@@ -9,7 +9,7 @@ class Router(object):
     """Simple object store for REST API routes."""
 
     def __init__(self, object_type, base, version, **routes):
-        """Constructor.
+        """Object store for REST API routes.
 
         Args:
             object_type (:obj:`str`):

--- a/axonius_api_client/api/users_devices.py
+++ b/axonius_api_client/api/users_devices.py
@@ -186,7 +186,6 @@ class UserDeviceMixin(mixins.ModelUserDevice, mixins.Mixins):
                 "use_post={}".format(use_post),
             ]
             self._log.debug(tools.join_comma(obj=msg))
-
             page = self._get(
                 query=query,
                 fields=fields,
@@ -649,7 +648,6 @@ class SavedQuery(mixins.Child):
 
         return self._parent._request(method="get", path=path, params=params)
 
-    # REST API FR: Have backend process expressions on add if none supplied
     def add(
         self,
         name,
@@ -1203,14 +1201,6 @@ class Fields(mixins.Child):
 
 class Reports(mixins.Child):
     """Pass."""
-
-    # FUTURE: OTHER REPORTS:
-    """
-    get all users
-    for each device
-        find any users whose username matches last logged in user
-        device[users] = found_users
-    """
 
     def missing_adapters(self, rows, adapters=None, fields=None):
         """Pass."""

--- a/axonius_api_client/auth.py
+++ b/axonius_api_client/auth.py
@@ -61,7 +61,7 @@ class Mixins(object):
     """:obj:`bool`: Attribute checked by :meth:`is_logged_in`."""
 
     def __init__(self, http, creds, **kwargs):
-        """Constructor.
+        """Mixins for Model.
 
         Args:
             http (:obj:`axonius_api_client.http.Http`):
@@ -176,7 +176,7 @@ class ApiKey(Mixins, Model):
     """Authentication method using API key & API secret."""
 
     def __init__(self, http, key, secret, **kwargs):
-        """Constructor.
+        """Authenticate using API key & API secret.
 
         Args:
             http (:obj:`axonius_api_client.http.Http`):

--- a/axonius_api_client/cli/__init__.py
+++ b/axonius_api_client/cli/__init__.py
@@ -8,20 +8,6 @@ from .. import constants, version
 from . import cli_constants, click_ext, context, grp_adapters, grp_objects, grp_tools
 
 
-"""
-FUTURE:
-* accept ini based config for adapters cnx add
-* better way to handle adapters cnx skips in prompts - maybe custom click type?
-* grp_enforcements
-* wrap json datasets with objtype info
-* --verbose/--no-verbose to silence echo_ok
-* way to only import cli stuffs so package doesnt see unless needed
-* add cert_human logic
-* prompt does not use CR when re-prompting on empty var with hide_input=False
-* add doc links
-"""
-
-
 @click.group(
     cls=click_ext.AliasedGroup,
     context_settings=cli_constants.CONTEXT_SETTINGS,

--- a/axonius_api_client/cli/__init__.py
+++ b/axonius_api_client/cli/__init__.py
@@ -179,6 +179,36 @@ All of the options listed above must be supplied BEFORE any commands or groups.
     show_default=True,
 )
 @click.option(
+    "--cert-client-both",
+    "-ccb",
+    "cert_client_both",
+    type=click.Path(exists=True, resolve_path=True),
+    help="Path to client SSL certificate and private key in one file for mutual TLS.",
+    metavar="PATH",
+    show_envvar=True,
+    show_default=True,
+)
+@click.option(
+    "--cert-client-cert",
+    "-ccc",
+    "cert_client_cert",
+    type=click.Path(exists=True, resolve_path=True),
+    help="Path to client SSL certificate for mutual TLS.",
+    metavar="PATH",
+    show_envvar=True,
+    show_default=True,
+)
+@click.option(
+    "--cert-client-key",
+    "-cck",
+    "cert_client_key",
+    type=click.Path(exists=True, resolve_path=True),
+    help="Path to client SSL private key for mutual TLS",
+    metavar="PATH",
+    show_envvar=True,
+    show_default=True,
+)
+@click.option(
     "--certpath",
     "-cp",
     "certpath",
@@ -240,6 +270,9 @@ def cli(
     log_file_path,
     log_file_max_mb,
     log_file_max_files,
+    cert_client_cert,
+    cert_client_key,
+    cert_client_both,
     proxy,
     certpath,
     certverify,
@@ -265,6 +298,9 @@ def cli(
     ctx._connect_args["log_file_max_mb"] = log_file_max_mb
     ctx._connect_args["log_file_max_files"] = log_file_max_files
     ctx._connect_args["proxy"] = proxy
+    ctx._connect_args["cert_client_cert"] = cert_client_cert
+    ctx._connect_args["cert_client_key"] = cert_client_key
+    ctx._connect_args["cert_client_both"] = cert_client_both
     ctx._connect_args["certpath"] = certpath
     ctx._connect_args["certverify"] = certverify
     ctx._connect_args["certwarn"] = certwarn

--- a/axonius_api_client/cli/context.py
+++ b/axonius_api_client/cli/context.py
@@ -100,9 +100,7 @@ class Context(object):
     @staticmethod
     def echo_error(msg, abort=True, **kwargs):
         """Pass."""
-        click.secho(
-            cli_constants.ERROR_TMPL.format(msg=msg), **cli_constants.ERROR_ARGS
-        )
+        click.secho(cli_constants.ERROR_TMPL.format(msg=msg), **cli_constants.ERROR_ARGS)
         if abort:
             sys.exit(1)
 

--- a/axonius_api_client/cli/grp_cnx/cmd_get.py
+++ b/axonius_api_client/cli/grp_cnx/cmd_get.py
@@ -142,7 +142,7 @@ def cmd(
         )
 
         filter3 = client.adapters.cnx.filter_by_uuids(
-            cnxs=filter1, value=uuids, value_regex=uuid_regex
+            cnxs=filter2, value=uuids, value_regex=uuid_regex
         )
         grp_common.check_empty(
             ctx=ctx,

--- a/axonius_api_client/cli/grp_objects/cmd_get.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get.py
@@ -20,6 +20,7 @@ from . import grp_common
 @options.OPT_QUERY
 @options.OPT_QUERY_FILE
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @click.pass_context
@@ -36,6 +37,7 @@ def cmd(
     query,
     query_file,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -50,7 +52,11 @@ def cmd(
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
         raw_data = api.get(
-            query=query, fields=fields, fields_default=fields_default, max_rows=max_rows
+            query=query,
+            fields=fields,
+            fields_regex=fields_regex,
+            fields_default=fields_default,
+            max_rows=max_rows,
         )
 
     grp_common.echo_response(ctx=ctx, raw_data=raw_data, api=api)

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_hostname.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_hostname.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -42,6 +43,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -62,6 +64,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_hostname",

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_ip.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_ip.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -42,6 +43,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -62,6 +64,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_ip",

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_mac.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_mac.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -42,6 +43,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -62,6 +64,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_mac",

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_mail.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_mail.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -42,6 +43,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -62,6 +64,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_mail",

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_saved_query.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_saved_query.py
@@ -19,6 +19,8 @@ from . import grp_common
 @options.OPT_EXPORT_FORMAT
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
+@options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_MAX_ROWS
 @click.option(
     "--name",
@@ -38,6 +40,8 @@ def cmd(
     export_path,
     export_overwrite,
     export_delim,
+    fields,
+    fields_regex,
     name,
     max_rows,
 ):
@@ -48,7 +52,9 @@ def cmd(
     api = getattr(client, p_grp)
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        raw_data = api.get_by_saved_query(name=name, max_rows=max_rows)
+        raw_data = api.get_by_saved_query(
+            name=name, fields=fields, fields_regex=fields_regex, max_rows=max_rows
+        )
 
     grp_common.echo_response(ctx=ctx, raw_data=raw_data, api=api)
 

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_subnet.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_subnet.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -47,6 +48,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -67,6 +69,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_subnet",

--- a/axonius_api_client/cli/grp_objects/cmd_get_by_username.py
+++ b/axonius_api_client/cli/grp_objects/cmd_get_by_username.py
@@ -18,6 +18,7 @@ from . import grp_common
 @options.OPT_EXPORT_OVERWRITE
 @options.OPT_EXPORT_DELIM
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @options.OPT_MAX_ROWS
 @options.OPT_GET_BY_PRE_QUERY
@@ -42,6 +43,7 @@ def cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
 ):
@@ -62,6 +64,7 @@ def cmd(
         query_pre=query_pre,
         query_post=query_post,
         fields=fields,
+        fields_regex=fields_regex,
         fields_default=fields_default,
         max_rows=max_rows,
         method="get_by_username",

--- a/axonius_api_client/cli/grp_objects/grp_common.py
+++ b/axonius_api_client/cli/grp_objects/grp_common.py
@@ -23,6 +23,7 @@ def get_by_cmd(
     query_pre,
     query_post,
     fields,
+    fields_regex,
     fields_default,
     max_rows,
     method,
@@ -42,6 +43,7 @@ def get_by_cmd(
             query_pre=query_pre,
             query_post=query_post,
             fields=fields,
+            fields_regex=fields_regex,
             fields_default=fields_default,
             max_rows=max_rows,
         )

--- a/axonius_api_client/cli/grp_saved_query/cmd_add.py
+++ b/axonius_api_client/cli/grp_saved_query/cmd_add.py
@@ -21,6 +21,7 @@ from . import grp_common
 @options.OPT_QUERY
 @options.OPT_QUERY_FILE
 @options.OPT_FIELDS
+@options.OPT_FIELDS_REGEX
 @options.OPT_FIELDS_DEFAULT
 @click.option(
     "--name",
@@ -82,6 +83,7 @@ def cmd(
     query,
     query_file,
     fields,
+    fields_regex,
     fields_default,
     sort_field,
     sort_descending,
@@ -103,6 +105,7 @@ def cmd(
             name=name,
             query=query,
             fields=fields,
+            fields_regex=fields_regex,
             fields_default=fields_default,
             sort=sort_field,
             sort_descending=sort_descending,

--- a/axonius_api_client/cli/options.py
+++ b/axonius_api_client/cli/options.py
@@ -132,6 +132,15 @@ OPT_FIELDS = click.option(
     multiple=True,
     show_envvar=True,
 )
+OPT_FIELDS_REGEX = click.option(
+    "--field-regex",
+    "-fr",
+    "fields_regex",
+    help="Fields (columns) to include in the format of adapter:field (regex).",
+    metavar="ADAPTER:FIELD",
+    multiple=True,
+    show_envvar=True,
+)
 OPT_FIELDS_DEFAULT = click.option(
     "--no-fields-default",
     "-nfd",

--- a/axonius_api_client/cli/serial.py
+++ b/axonius_api_client/cli/serial.py
@@ -134,9 +134,7 @@ def join_cr(obj, is_cell=False, joiner="\n"):
     return str_obj
 
 
-def dictwriter(
-    rows, stream=None, headers=None, quoting=cli_constants.QUOTING, **kwargs
-):
+def dictwriter(rows, stream=None, headers=None, quoting=cli_constants.QUOTING, **kwargs):
     """Pass."""
     fh = stream or tools.six.StringIO()
 

--- a/axonius_api_client/connect.py
+++ b/axonius_api_client/connect.py
@@ -45,6 +45,9 @@ class Connect(object):
         certpath = kwargs.get("certpath", "")
         certverify = kwargs.get("certverify", False)
         certwarn = kwargs.get("certwarn", True)
+        cert_client_both = kwargs.get("cert_client_both", None)
+        cert_client_cert = kwargs.get("cert_client_cert", None)
+        cert_client_key = kwargs.get("cert_client_key", None)
         save_history = kwargs.get("save_history", False)
         log_request_attrs = kwargs.get("log_request_attrs", False)
         log_response_attrs = kwargs.get("log_response_attrs", False)
@@ -94,6 +97,9 @@ class Connect(object):
             "certpath": certpath,
             "certwarn": certwarn,
             "certverify": certverify,
+            "cert_client_both": cert_client_both,
+            "cert_client_cert": cert_client_cert,
+            "cert_client_key": cert_client_key,
             "log_level": log_level_http,
             "log_request_attrs": log_request_attrs,
             "log_response_attrs": log_response_attrs,

--- a/axonius_api_client/exceptions.py
+++ b/axonius_api_client/exceptions.py
@@ -23,7 +23,7 @@ class BetaWarning(AxonWarning):
     """Pass."""
 
     def __init__(self, obj):
-        """Constructor."""
+        """Pass."""
         msg = "Object {obj} is considered **BETA** status! Here be dragons..."
         msg = msg.format(obj=obj)
 
@@ -54,7 +54,7 @@ class CnxDeleteForce(CnxError):
     """Pass."""
 
     def __init__(self, cnxinfo):
-        """Constructor.
+        """Pass.
 
         Args:
             added (:obj:`requests.Response`):
@@ -79,7 +79,7 @@ class CnxDeleteFailed(CnxError):
     """Pass."""
 
     def __init__(self, cnxinfo, response):
-        """Constructor."""
+        """Pass."""
         from . import tools
 
         self.cnxinfo = cnxinfo
@@ -101,7 +101,7 @@ class CnxDeleteWarning(CnxWarning):
     """Pass."""
 
     def __init__(self, cnxinfo, sleep):
-        """Constructor."""
+        """Pass."""
         from . import tools
 
         msg = ["Connection info: {cnxinfo}", "Will delete connection in {s} seconds!!"]
@@ -114,7 +114,7 @@ class CnxDeleteFailedWarning(CnxWarning):
     """Pass."""
 
     def __init__(self, cnxinfo, response):
-        """Constructor."""
+        """Pass."""
         from . import tools
 
         self.cnxinfo = cnxinfo
@@ -136,7 +136,7 @@ class CnxRefetchFailure(CnxError):
     def __init__(
         self, response, adapter, node, filter_value, filter_method, known=None, **kwargs
     ):
-        """Constructor.
+        """Pass.
 
         Args:
             response (:obj:`requests.Response`):
@@ -176,7 +176,7 @@ class CnxCsvWarning(CnxWarning):
     """Pass."""
 
     def __init__(self, ids_type, ids, name, headers):
-        """Constructor."""
+        """Pass."""
         msg = "No {ids_type} identifiers {ids} found in CSV file {name} headers {h}"
         msg = msg.format(ids_type=ids_type, ids=ids, name=name, h=headers)
 
@@ -187,7 +187,7 @@ class CnxConnectFailure(CnxError):
     """Error when response has error key in JSON."""
 
     def __init__(self, response, adapter, node):
-        """Constructor.
+        """Pass.
 
         Args:
             response (:obj:`requests.Response`):
@@ -346,7 +346,7 @@ class ResponseError(ApiError):
     """Parent exception for any response error."""
 
     def __init__(self, response, error="", exc=None, details=True, bodies=True):
-        """Constructor.
+        """Pass.
 
         Args:
             response (:obj:`requests.Response`):
@@ -418,7 +418,7 @@ class JsonInvalid(ResponseError):
     """Error when response has invalid JSON."""
 
     def __init__(self, response, exc=None, details=True, bodies=True):
-        """Constructor.
+        """Pass.
 
         Args:
             response (:obj:`requests.Response`):
@@ -439,7 +439,7 @@ class JsonError(ResponseError):
     """Error when response has error key in JSON."""
 
     def __init__(self, response, data, exc=None, details=True, bodies=False):
-        """Constructor.
+        """Pass.
 
         Args:
             response (:obj:`requests.Response`):
@@ -479,7 +479,7 @@ class ValueNotFound(ApiError):
         **kwargs
         # fmt: on
     ):
-        """Constructor."""
+        """Pass."""
         from . import tools
 
         self.value = value
@@ -514,7 +514,7 @@ class InvalidCredentials(AuthError):
     """Error on failed login."""
 
     def __init__(self, auth, exc=None):
-        """Constructor.
+        """Pass.
 
         Args:
             auth (:obj:`axonius_api_client.models.AuthModel`):
@@ -540,7 +540,7 @@ class NotLoggedIn(AuthError):
     """Error when not logged in."""
 
     def __init__(self, auth):
-        """Constructor.
+        """Pass.
 
         Args:
             auth (:obj:`axonius_api_client.models.AuthModel`):
@@ -559,7 +559,7 @@ class AlreadyLoggedIn(AuthError):
     """Error when already logged in."""
 
     def __init__(self, auth):
-        """Constructor.
+        """Pass.
 
         Args:
             auth (:obj:`axonius_api_client.models.AuthModel`):

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -38,7 +38,7 @@ class Http(object):
         **kwargs
         # fmt: on
     ):
-        """Constructor.
+        """HTTP client for sending requests usings :obj:`requests.Session`.
 
         Args:
             url (:obj:`str` or :obj:`axonius_api_client.http.parser.ParserUrl`):
@@ -352,7 +352,7 @@ class ParserUrl(object):
     """Parse a URL and ensure it has the neccessary bits."""
 
     def __init__(self, url, default_scheme="https"):
-        """Constructor.
+        """Parse a URL and ensure it has the neccessary bits.
 
         Args:
             url (:obj:`str`):

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -291,9 +291,7 @@ class Http(object):
 
         if self._LOG_REQUEST_BODY:
             msg = "request body:\n{body}"
-            msg = msg.format(
-                body=tools.json_dump(obj=prepped_request.body, error=False)
-            )
+            msg = msg.format(body=tools.json_dump(obj=prepped_request.body, error=False))
             self._log.debug(msg)
 
         response = self.session.send(**send_args)

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -161,18 +161,18 @@ class Http(object):
 
         if cert_client_both:
             tools.path_read(obj=cert_client_both)
-            self.session.cert = cert_client_both
+            self.session.cert = format(cert_client_both)
         elif cert_client_cert or cert_client_key:
-            if not cert_client_cert and cert_client_key:
+            if not all([cert_client_cert, cert_client_key]):
                 error = (
-                    "You must supply both a cert_client_cert and cert_client_key"
-                    "or use cert_client_both!"
+                    "You must supply both a 'cert_client_cert' and 'cert_client_key'"
+                    " or use 'cert_client_both'!"
                 )
                 raise exceptions.HttpError(error)
 
             tools.path_read(obj=cert_client_cert)
             tools.path_read(obj=cert_client_key)
-            self.session.cert = (cert_client_cert, cert_client_key)
+            self.session.cert = (format(cert_client_cert), format(cert_client_key))
 
         self._LOG_REQUEST_BODY = kwargs.get("log_request_body", False)
         """:obj:`bool`: Log the full request body."""

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -30,6 +30,9 @@ class Http(object):
         certpath=None,
         certwarn=True,
         certverify=False,
+        cert_client_both=None,
+        cert_client_cert=None,
+        cert_client_key=None,
         http_proxy=None,
         https_proxy=None,
         save_last=True,
@@ -155,6 +158,21 @@ class Http(object):
         self.session.proxies = {}
         self.session.proxies["https"] = https_proxy
         self.session.proxies["http"] = http_proxy
+
+        if cert_client_both:
+            tools.path_read(obj=cert_client_both)
+            self.session.cert = cert_client_both
+        elif cert_client_cert or cert_client_key:
+            if not cert_client_cert and cert_client_key:
+                error = (
+                    "You must supply both a cert_client_cert and cert_client_key"
+                    "or use cert_client_both!"
+                )
+                raise exceptions.HttpError(error)
+
+            tools.path_read(obj=cert_client_cert)
+            tools.path_read(obj=cert_client_key)
+            self.session.cert = (cert_client_cert, cert_client_key)
 
         self._LOG_REQUEST_BODY = kwargs.get("log_request_body", False)
         """:obj:`bool`: Log the full request body."""

--- a/axonius_api_client/tests/tests_api/test_api_adapters.py
+++ b/axonius_api_client/tests/tests_api/test_api_adapters.py
@@ -649,14 +649,10 @@ class TestCnx(object):
 
     def test_check_failure(self, apiobj):
         """Pass."""
-        new_config = {
-            "domain": "https:/172.254.254.254:9999",
-            "username": "x",
-            "password": "x",
-            "verify_ssl": False,
-        }
+        config = dict(dc_name="badwolf_check_failure")
+        config.update(AD_CONFIG_SCHEMA)
 
-        cnx = apiobj.cnx.add(adapter="tanium", config=new_config, error=False)
+        cnx = apiobj.cnx.add(adapter="active_directory", config=config, error=False)
 
         with pytest.raises(exceptions.CnxConnectFailure):
             apiobj.cnx.check(cnx=cnx, error=True)

--- a/axonius_api_client/tests/tests_api/test_api_adapters.py
+++ b/axonius_api_client/tests/tests_api/test_api_adapters.py
@@ -445,9 +445,7 @@ class TestCnx(object):
         adapter = apiobj.get_single("active_directory")
 
         with pytest.raises(exceptions.CnxConnectFailure) as exc:
-            apiobj.cnx.add(
-                adapter=adapter, config=config, parse_config=True, error=True
-            )
+            apiobj.cnx.add(adapter=adapter, config=config, parse_config=True, error=True)
 
         refetched = apiobj.cnx.refetch(
             adapter_name=adapter["name"],

--- a/axonius_api_client/tests/tests_api/test_api_adapters.py
+++ b/axonius_api_client/tests/tests_api/test_api_adapters.py
@@ -12,9 +12,6 @@ from axonius_api_client import constants, exceptions, tools
 
 from .. import utils
 
-# REST API BR: adding cnx with parsed config instead of raw config breaks adapters._get()
-# FUTURE: add atexit to verify no badwolf cnxs?
-
 CSV_FILENAME = "badwolf.csv"
 CSV_FIELDS = ["mac_address", "field1"]
 CSV_ROW = ["01:37:53:9E:82:7C", "e"]
@@ -1289,7 +1286,6 @@ class TestRawAdapters(object):
             assert isinstance(req, tools.STR)
             item_names = [x["name"] for x in items]
 
-            # FUTURE: schema's are defining required items that dont exist in items
             if req not in item_names:
                 msg = "Schema for {} has required item {!r} not in defined items {}"
                 msg = msg.format(name, req, item_names)

--- a/axonius_api_client/tests/tests_api/test_api_adapters.py
+++ b/axonius_api_client/tests/tests_api/test_api_adapters.py
@@ -66,6 +66,13 @@ FAKE_ADAPTER_NOCLIENTS = {
     "status": None,
 }
 FAKE_ADAPTERS = [FAKE_ADAPTER_CNXS_BAD, FAKE_ADAPTER_CNXS_OK, FAKE_ADAPTER_NOCLIENTS]
+AD_CONFIG_SCHEMA = dict(
+    user=CSV_FILENAME,
+    password=CSV_FILENAME,
+    do_not_fetch_users=False,
+    fetch_disabled_devices=True,
+    fetch_disabled_users=True,
+)
 
 
 @pytest.fixture(scope="module")
@@ -436,11 +443,8 @@ class TestCnx(object):
 
     def test_add_delete(self, apiobj, csv_adapter):
         """Pass."""
-        config = dict(
-            dc_name="badwolf_public_add_delete",
-            user=CSV_FILENAME,
-            password=CSV_FILENAME,
-        )
+        config = dict(dc_name="badwolf_public_add_delete")
+        config.update(AD_CONFIG_SCHEMA)
 
         adapter = apiobj.get_single("active_directory")
 
@@ -578,11 +582,8 @@ class TestCnx(object):
 
     def test_update_failure(self, apiobj):
         """Pass."""
-        config = dict(
-            dc_name="badwolf_public_update_failure",
-            user=CSV_FILENAME,
-            password=CSV_FILENAME,
-        )
+        config = dict(dc_name="badwolf_public_update_failure")
+        config.update(AD_CONFIG_SCHEMA)
 
         cnx = apiobj.cnx.add(
             adapter="active_directory", config=config, parse_config=True, error=False
@@ -604,11 +605,9 @@ class TestCnx(object):
 
     def test_update_parse(self, apiobj):
         """Pass."""
-        config = dict(
-            dc_name="badwolf_public_update_parse",
-            user=CSV_FILENAME,
-            password=CSV_FILENAME,
-        )
+        config = dict(dc_name="badwolf_public_update_parse")
+        config.update(AD_CONFIG_SCHEMA)
+
         cnx = apiobj.cnx.add(
             adapter="active_directory", config=config, parse_config=True, error=False
         )

--- a/axonius_api_client/tests/tests_api/test_api_adapters.py
+++ b/axonius_api_client/tests/tests_api/test_api_adapters.py
@@ -1305,6 +1305,7 @@ class TestRawAdapters(object):
             item_enum = item.pop("enum", [])
             item_default = item.pop("default", "")
             item_items = item.pop("items", {})
+            item_req = item.pop("required", False)
 
             assert isinstance(item_name, tools.STR) and item_name
             assert isinstance(item_type, tools.STR) and item_type
@@ -1316,6 +1317,7 @@ class TestRawAdapters(object):
                 assert isinstance(x, tools.STR)
             assert isinstance(item_format, tools.STR)
             assert isinstance(item_description, tools.STR)
+            assert isinstance(item_req, bool)
             assert item_type in ["number", "integer", "string", "bool", "array", "file"]
             assert not item
 

--- a/axonius_api_client/tests/tests_api/test_api_enforcements.py
+++ b/axonius_api_client/tests/tests_api/test_api_enforcements.py
@@ -2,6 +2,7 @@
 """Test suite for axonapi.api.users_devices."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import time
 import warnings
 
 import pytest
@@ -19,25 +20,20 @@ DEPLOY_FILE_NAME = "badwolf.sh"
 DEPLOY_FILE_CONTENTS = b"#!/bin/bash\necho badwolf!"
 
 CREATE_EC_NAME = "Badwolf EC Example"
-CREATE_EC_TRIGGERS = [
-    {
-        "name": "Trigger",
-        "view": {
-            "name": "Users Created in Last 30 Days",
-            "entity": "users",
-        },  # FUTURE: public create will need to get sq!
-        "conditions": {
-            "new_entities": False,
-            "previous_entities": False,
-            "above": 1,
-            "below": 0,
-        },  # FUTURE: need public build_trigger method
-        "period": "never",
-        "run_on": "AllEntities",
-    }
-]
+CREATE_EC_TRIGGER1 = {
+    "name": "Trigger",
+    "conditions": {
+        "new_entities": False,
+        "previous_entities": False,
+        "above": 1,
+        "below": 0,
+    },
+    "period": "never",
+    "run_on": "AllEntities",
+}
+
 CREATE_EC_ACTION_MAIN = {
-    "name": "Badwolf Create Notification",
+    "name": "Badwolf Create Notification {}".format(time.time()),
     "action": {"action_name": "create_notification", "config": {}},
 }
 
@@ -109,8 +105,12 @@ class TestEnforcements(object):
             assert isinstance(deleted["deleted"], tools.INT)
             assert deleted["deleted"] == 1
 
+        trigger_name = apiobj.users.saved_query.get()[0]["name"]
+        trigger = {"view": {"name": trigger_name, "entity": "users"}}
+        trigger.update(CREATE_EC_TRIGGER1)
+
         created = apiobj._create(
-            name=CREATE_EC_NAME, main=CREATE_EC_ACTION_MAIN, triggers=CREATE_EC_TRIGGERS
+            name=CREATE_EC_NAME, main=CREATE_EC_ACTION_MAIN, triggers=[trigger]
         )
         assert isinstance(created, tools.STR)
 
@@ -135,7 +135,7 @@ class TestEnforcements(object):
         assert isinstance(found["last_updated"], tools.STR)
         assert "triggers.last_triggered" in found
         assert "triggers.times_triggered" in found
-        assert found["triggers.view.name"] == CREATE_EC_TRIGGERS[0]["view"]["name"]
+        assert found["triggers.view.name"] == trigger_name
 
         found_by_id = apiobj.get_by_id(found["uuid"])
         assert isinstance(found_by_id, dict)
@@ -173,7 +173,6 @@ class TestRunActions(object):
         for i in ["deploy", "shell", "upload_file"]:
             assert i in data
 
-    # FUTURE:
     # this returns nothing...
     # AND no action shows up in GUI for dvc
     # AND no task shows up in EC
@@ -203,7 +202,7 @@ class TestRunActions(object):
         assert data["filename"] == DEPLOY_FILE_NAME
         return data
 
-    # FUTURE: returns nadda
+    # returns nadda
     def test__upload_deploy(self, apiobj, uploaded_file):
         """Pass."""
         devices = apiobj.devices._get(query=LINUX_QUERY, page_size=1, row_start=0)

--- a/axonius_api_client/tests/tests_api/test_api_enforcements.py
+++ b/axonius_api_client/tests/tests_api/test_api_enforcements.py
@@ -52,9 +52,7 @@ def apiobj(request):
 
     utils.check_apiobj(authobj=auth, apiobj=api)
 
-    utils.check_apiobj_children(
-        apiobj=api, runaction=axonapi.api.enforcements.RunAction
-    )
+    utils.check_apiobj_children(apiobj=api, runaction=axonapi.api.enforcements.RunAction)
 
     utils.check_apiobj_xref(
         apiobj=api,

--- a/axonius_api_client/tests/tests_api/test_api_users_devices.py
+++ b/axonius_api_client/tests/tests_api/test_api_users_devices.py
@@ -2,6 +2,7 @@
 """Test suite for axonapi.api.users_devices."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
 import json
 import re
 
@@ -1054,7 +1055,7 @@ class TestSavedQuery(Base):
 
     def test__add_get_delete(self, apiobj):
         """Pass."""
-        name = "badwolf_test__add_get_delete"
+        name = "badwolf_test__add_get_delete {}".format(datetime.datetime.now())
 
         asset = self.get_single_asset(apiobj=apiobj, query=None, refetch=None)
 
@@ -1081,7 +1082,7 @@ class TestSavedQuery(Base):
 
     def test_add_delete(self, apiobj):
         """Pass."""
-        name = "badwolf_test_add_delete"
+        name = "badwolf_test_add_get_delete {}".format(datetime.datetime.now())
 
         asset = self.get_single_asset(apiobj=apiobj, query=None, refetch=None)
 
@@ -1100,7 +1101,7 @@ class TestSavedQuery(Base):
 
     def test_add_delete_sort(self, apiobj):
         """Pass."""
-        name = "badwolf_test_add_delete_sort"
+        name = "badwolf_test_add_delete_sort {}".format(datetime.datetime.now())
         single_field = apiobj.TEST_DATA["single_field"]
         asset = self.get_single_asset(apiobj=apiobj, query=None, refetch=None)
 
@@ -1122,7 +1123,7 @@ class TestSavedQuery(Base):
 
     def test_add_delete_colfilter(self, apiobj):
         """Pass."""
-        name = "badwolf_test_add_delete_colfilter"
+        name = "badwolf_test_add_delete_colfilter {}".format(datetime.datetime.now())
         single_field = apiobj.TEST_DATA["single_field"]
         asset = self.get_single_asset(apiobj=apiobj, query=None, refetch=None)
 
@@ -1259,7 +1260,7 @@ class TestParsedFields(Base):
         if format:
             assert format in FIELD_FORMATS, format
 
-        val_items(aname=aname, items=items)
+        val_items(aname="{}:{}".format(aname, fname), items=items)
 
 
 @pytest.mark.parametrize(
@@ -1365,7 +1366,7 @@ class TestRawFields(Base):
             for enum in enums:
                 assert isinstance(enum, tools.STR) or tools.is_int(enum)
 
-            val_items(aname=aname, items=items)
+            val_items(aname="{}:{}".format(aname, name), items=items)
 
 
 def val_items(aname, items):
@@ -1381,20 +1382,35 @@ def val_items(aname, items):
 
         # uncommon
         enums = items.pop("enum", [])
-        format = items.pop("format", "")
+        fformat = items.pop("format", "")
         iitems = items.pop("items", [])
         name = items.pop("name", "")
         title = items.pop("title", "")
         description = items.pop("description", "")
         branched = items.pop("branched", False)
         dynamic = items.pop("dynamic", False)
+        source = items.pop("source", {})
+        assert isinstance(source, dict)
 
-        if format:
-            assert format in SCHEMA_FIELD_FORMATS, format
+        if source:
+            source_key = source.pop("key")
+            assert isinstance(source_key, tools.STR)
+
+            source_options = source.pop("options")
+            assert isinstance(source_options, dict)
+
+            options_allow = source_options.pop("allow-custom-option")
+            assert isinstance(options_allow, bool)
+
+            assert not source, source
+            assert not source_options, source_options
+
+        if fformat:
+            assert fformat in SCHEMA_FIELD_FORMATS, fformat
 
         assert isinstance(enums, tools.LIST)
         assert isinstance(iitems, tools.LIST) or isinstance(iitems, dict)
-        assert isinstance(format, tools.STR)
+        assert isinstance(fformat, tools.STR)
         assert isinstance(name, tools.STR)
         assert isinstance(title, tools.STR)
         assert isinstance(description, tools.STR)

--- a/axonius_api_client/tests/tests_api/test_api_users_devices.py
+++ b/axonius_api_client/tests/tests_api/test_api_users_devices.py
@@ -48,10 +48,7 @@ USERS_TEST_DATA = {
         {"search": "active_directory_adapter", "exp": "active_directory"},
         {"search": "active_directory", "exp": "active_directory"},
     ],
-    "single_field": {
-        "search": "generic:username",
-        "exp": "specific_data.data.username",
-    },
+    "single_field": {"search": "username", "exp": "specific_data.data.username"},
     "fields": [
         {"search": "username", "exp": ["specific_data.data.username"]},
         {"search": "generic:username", "exp": ["specific_data.data.username"]},
@@ -92,10 +89,7 @@ DEVICES_TEST_DATA = {
         {"search": "active_directory_adapter", "exp": "active_directory"},
         {"search": "active_directory", "exp": "active_directory"},
     ],
-    "single_field": {
-        "search": "generic:hostname",
-        "exp": "specific_data.data.hostname",
-    },
+    "single_field": {"search": "hostname", "exp": "specific_data.data.hostname"},
     "fields": [
         {
             "search": "network_interfaces.ips",
@@ -585,6 +579,29 @@ class TestFields(Base):
         assert name is None
         assert fields == {}
 
+    def test_find_re(self, apiobj):
+        """Pass."""
+        single = apiobj.TEST_DATA["single_field"]["search"]
+        found = apiobj.fields.find_regex(field=single, all_fields=apiobj.ALL_FIELDS)
+        assert found
+        assert isinstance(found, tools.LIST)
+        assert all([single in x for x in found])
+
+        found = apiobj.fields.find_regex(
+            field=".:" + single, all_fields=apiobj.ALL_FIELDS
+        )
+        assert found
+        assert isinstance(found, tools.LIST)
+        assert all([single in x for x in found])
+
+        found = apiobj.fields.find_regex(
+            field="generic:" + single, all_fields=apiobj.ALL_FIELDS
+        )
+        assert found
+        assert isinstance(found, tools.LIST)
+        assert all([single in x for x in found])
+        assert all(["specific_data.data" in x for x in found])
+
     def test_find(self, apiobj):
         """Pass."""
         for info in apiobj.TEST_DATA["fields"]:
@@ -656,6 +673,22 @@ class TestFields(Base):
                     iexp.append(x)
 
             assert sorted(found) == sorted(iexp)
+
+    def test_validateregex(self, apiobj):
+        """Pass."""
+        single = apiobj.TEST_DATA["single_field"]["search"]
+        for info in apiobj.TEST_DATA["val_fields"]:
+            isearch = info["search"]
+            iexp = info["exp"]
+            found = apiobj.fields.validate(
+                fields=isearch,
+                fields_regex=single,
+                all_fields=apiobj.ALL_FIELDS,
+                default=False,
+            )
+            assert isinstance(found, tools.LIST)
+            for x in iexp:
+                assert x in found
 
     def test_validate_ignores(self, apiobj):
         """Pass."""

--- a/axonius_api_client/tests/tests_api/test_api_users_devices.py
+++ b/axonius_api_client/tests/tests_api/test_api_users_devices.py
@@ -808,6 +808,28 @@ class TestLabels(Base):
 class TestSavedQuery(Base):
     """Pass."""
 
+    def test_add_delete_readd(self, apiobj):
+        """Pass."""
+        # TODO: test that add SQ, delete SQ, and re-add SQ with same name
+        # does not show up in get all SQ
+        # When fixed in REST API, re-work this test to not expect an exception
+        name = "badwolf_test_add_get_delete_readd {}".format(datetime.datetime.now())
+
+        asset = self.get_single_asset(apiobj=apiobj, query=None, refetch=None)
+
+        query = QUERY_ID(**asset)
+
+        added = apiobj.saved_query.add(name=name, query=query)
+        assert isinstance(added, dict)
+        assert added["name"] == name
+        assert added["view"]["query"]["filter"] == query
+
+        deleted = apiobj.saved_query.delete(rows=added)
+        assert not deleted
+
+        with pytest.raises(exceptions.ValueNotFound):
+            apiobj.saved_query.add(name=name, query=query)
+
     def test__get(self, apiobj):
         """Pass."""
         data = apiobj.saved_query._get()

--- a/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
+++ b/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
@@ -63,6 +63,80 @@ class TestGrpCnx(object):
         json2 = tools.json_load(stdout2)
         assert isinstance(json2, tools.LIST)
 
+    def test_get_cnx_by_uuid(self, request, monkeypatch):
+        """Pass."""
+        runner = utils.load_clirunner(request, monkeypatch)
+
+        args1 = ["adapters", "get"]
+        result1 = runner.invoke(cli=cli.cli, args=args1)
+
+        stderr1 = result1.stderr
+        stdout1 = result1.stdout
+        exit_code1 = result1.exit_code
+
+        assert stdout1
+        assert stderr1
+        assert exit_code1 == 0
+
+        json1 = tools.json_load(stdout1)
+        assert isinstance(json1, tools.LIST)
+        cnxs = [x["cnx"] for x in json1 if x["cnx"]]
+        cnx1_id = cnxs[0][0]["uuid"]
+
+        args2 = ["adapters", "cnx", "get", "--rows", "-", "--uuid", cnx1_id]
+        result2 = runner.invoke(cli=cli.cli, args=args2, input=stdout1)
+        del stdout1
+
+        stderr2 = result2.stderr
+        stdout2 = result2.stdout
+        exit_code2 = result2.exit_code
+
+        assert stdout2
+        assert stderr2
+        assert exit_code2 == 0
+
+        json2 = tools.json_load(stdout2)
+        assert isinstance(json2, tools.LIST)
+        assert json2[0]["uuid"] == cnx1_id
+        assert len(json2) == 1
+
+    def test_get_cnx_by_id(self, request, monkeypatch):
+        """Pass."""
+        runner = utils.load_clirunner(request, monkeypatch)
+
+        args1 = ["adapters", "get"]
+        result1 = runner.invoke(cli=cli.cli, args=args1)
+
+        stderr1 = result1.stderr
+        stdout1 = result1.stdout
+        exit_code1 = result1.exit_code
+
+        assert stdout1
+        assert stderr1
+        assert exit_code1 == 0
+
+        json1 = tools.json_load(stdout1)
+        assert isinstance(json1, tools.LIST)
+        cnxs = [x["cnx"] for x in json1 if x["cnx"]]
+        cnx1_id = cnxs[0][0]["id"]
+
+        args2 = ["adapters", "cnx", "get", "--rows", "-", "--id", cnx1_id]
+        result2 = runner.invoke(cli=cli.cli, args=args2, input=stdout1)
+        del stdout1
+
+        stderr2 = result2.stderr
+        stdout2 = result2.stdout
+        exit_code2 = result2.exit_code
+
+        assert stdout2
+        assert stderr2
+        assert exit_code2 == 0
+
+        json2 = tools.json_load(stdout2)
+        assert isinstance(json2, tools.LIST)
+        assert json2[0]["id"] == cnx1_id
+        assert len(json2) == 1
+
     def test_get_csv(self, request, monkeypatch):
         """Pass."""
         runner = utils.load_clirunner(request, monkeypatch)

--- a/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
+++ b/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
@@ -2,6 +2,7 @@
 """Test suite for axonius_api_client.tools."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import click
 import pytest
 
 from axonius_api_client import cli, tools  # , exceptions
@@ -16,6 +17,19 @@ def badwolf_cb(x, **kwargs):
 
 class TestGrpCnx(object):
     """Pass."""
+
+    @pytest.mark.parametrize(
+        "schema,ptype",
+        [
+            [{"type": "string", "enum": ["x", "a"]}, click.Choice],
+            [{"type": "badwolf"}, type(None)],
+            [{"type": "bool"}, click.BOOL.__class__],
+        ],
+    )
+    def test_determine_type(self, schema, ptype):
+        """Pass."""
+        ret = cli.grp_cnx.grp_common.determine_type(schema)
+        assert isinstance(ret, ptype), "{!r} {!r}".format(schema, ptype)
 
     def test_get_json(self, request, monkeypatch):
         """Pass."""
@@ -151,6 +165,41 @@ class TestGrpCnx(object):
 
         exp = "  Item must have keys:"
         assert errlines1[-2].startswith(exp)
+
+    def test_add_show_config_json(self, request, monkeypatch):
+        """Pass."""
+        runner = utils.load_clirunner(request, monkeypatch)
+
+        args1 = ["adapters", "cnx", "add", "--adapter", "csv", "--show-config", "json"]
+        result1 = runner.invoke(cli=cli.cli, args=args1)
+
+        stderr1 = result1.stderr
+        stdout1 = result1.stdout
+        exit_code1 = result1.exit_code
+
+        assert stdout1
+        assert stderr1
+        assert exit_code1 == 0
+
+        json1 = tools.json_load(stdout1)
+        assert isinstance(json1, tools.LIST)
+        for x in json1:
+            assert isinstance(x, dict)
+
+    def test_add_show_config_text(self, request, monkeypatch):
+        """Pass."""
+        runner = utils.load_clirunner(request, monkeypatch)
+
+        args1 = ["adapters", "cnx", "add", "--adapter", "csv", "--show-config", "text"]
+        result1 = runner.invoke(cli=cli.cli, args=args1)
+
+        stderr1 = result1.stderr
+        stdout1 = result1.stdout
+        exit_code1 = result1.exit_code
+
+        assert stdout1
+        assert stderr1
+        assert exit_code1 == 0
 
     def test_add_check_discover_delete_csv(self, request, monkeypatch):
         """Pass."""

--- a/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
+++ b/axonius_api_client/tests/tests_cli/test_cli_grp_cnx.py
@@ -179,6 +179,10 @@ axonshell a c de -r - -f -w 0
                 "--config",
                 "user_id={}".format(csv_file),
                 "--config",
+                "is_users_csv=False",
+                "--config",
+                "is_installed_sw=False",
+                "--config",
                 "csv={}".format(csv_path),
                 "--no-prompt-opt",
             ]
@@ -263,6 +267,10 @@ axonshell a c de -r - -f -w 0
                 "csv",
                 "--config",
                 "user_id={}".format(csv_file),
+                "--config",
+                "is_users_csv=False",
+                "--config",
+                "is_installed_sw=False",
                 "--config",
                 "csv={}".format(csv_path),
                 "--no-prompt-opt",
@@ -370,10 +378,11 @@ axonshell a c de -r - -f -w 0
             "ca_file": csv_file,
             "cert_file": csv_file,
             "private_key": csv_file,
-            "fetch_disabled_devices": "y",
-            "fetch_disabled_users": "y",
             "is_ad_gc": "y",
             "ldap_ou_whitelist": "badwolf1,badwolf2",
+            "do_not_fetch_users": "false",
+            "fetch_disabled_devices": "true",
+            "fetch_disabled_users": "true",
         }
 
         with runner.isolated_filesystem():
@@ -418,18 +427,30 @@ axonshell a c de -r - -f -w 0
 
         skips = ["ca_file", "cert_file", "private_key"]
 
+        """
+        dc_name
+        user
+        password
+        do_not_fetch_users
+        fetch_disabled_devices
+        fetch_disabled_users
+        dns_server_address
+        alternative_dns_suffix
+        use_ssl
+        ca_file
+        is_ad_gc
+        ldap_ou_whitelist
+        """
         configs = [
             "badwolf",  # dc_name
             "badwolf",  # user
             "badwolf",  # password
+            "n",  # do_not_fetch_users
+            "y",  # fetch_disabled_devices
+            "y",  # fetch_disabled_users
             "badwolf",  # dns_server_address
             "badwolf",  # alternative_dns_suffix
             "Unencrypted",  # use_ssl
-            # csv_file,  # ca_file
-            # csv_file,  # cert_file
-            # csv_file,  # private_key
-            "y",  # fetch_disabled_devices
-            "y",  # fetch_disabled_users
             "y",  # is_ad_gc
             "badwolf1,badwolf2",  # ldap_ou_whitelist
         ]

--- a/axonius_api_client/tests/tests_cli/test_cli_grp_objects.py
+++ b/axonius_api_client/tests/tests_cli/test_cli_grp_objects.py
@@ -387,7 +387,7 @@ class TestCmdGet(object):
             cmd,
             "get",
             "--query",
-            "(adapters > size(2))",
+            "(adapters > size(1))",
             "--export-format",
             "csv",
             "--max-rows",
@@ -411,7 +411,7 @@ class TestCmdGet(object):
         row1 = rows[0]
         row1_adapters = row1["adapters"]
         assert len(row1_adapters.splitlines()) == 1
-        assert len(row1_adapters.split(",")) > 2
+        assert len(row1_adapters.split(",")) >= 2
 
     def test_csv_complex(self, request, monkeypatch, cmd):
         """Pass."""

--- a/axonius_api_client/tests/tests_cli/test_cli_grp_saved_query.py
+++ b/axonius_api_client/tests/tests_cli/test_cli_grp_saved_query.py
@@ -2,6 +2,8 @@
 """Test suite for axonius_api_client.tools."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
+
 import pytest
 
 from axonius_api_client import cli, tools
@@ -16,7 +18,7 @@ class TestCmdAddGetDelete(object):
     def test_query_file(self, request, monkeypatch, cmd):
         """Pass."""
         runner = utils.load_clirunner(request, monkeypatch)
-        name = "badwolf"
+        name = "badwolf {}".format(datetime.datetime.now())
         field = "labels"
         cfilter = "generic:{}=a".format(field)
 
@@ -87,7 +89,7 @@ class TestCmdAddGetDelete(object):
     def test_json_cf(self, request, monkeypatch, cmd):
         """Pass."""
         runner = utils.load_clirunner(request, monkeypatch)
-        name = "badwolf"
+        name = "badwolf {}".format(datetime.datetime.now())
         query = "(adapters > size(0))"
         field = "labels"
         cfilter = "generic:{}=a".format(field)
@@ -152,7 +154,7 @@ class TestCmdAddGetDelete(object):
     def test_json_no_cf(self, request, monkeypatch, cmd):
         """Pass."""
         runner = utils.load_clirunner(request, monkeypatch)
-        name = "badwolf"
+        name = "badwolf {}".format(datetime.datetime.now())
         query = "(adapters > size(0))"
         field = "labels"
 
@@ -214,7 +216,7 @@ class TestCmdAddGetDelete(object):
     def test_bad_cf(self, request, monkeypatch, cmd):
         """Pass."""
         runner = utils.load_clirunner(request, monkeypatch)
-        name = "badwolf"
+        name = "badwolf {}".format(datetime.datetime.now())
         query = "(adapters > size(0))"
         field = "labels"
         cfilter = "generic:{}".format(field)

--- a/axonius_api_client/tests/tests_pkg/test_connect.py
+++ b/axonius_api_client/tests/tests_pkg/test_connect.py
@@ -81,9 +81,7 @@ class TestConnect(object):
         with pytest.raises(exceptions.ConnectError) as exc:
             c.start()
 
-        assert isinstance(
-            exc.value.exc, axonapi.http.requests.exceptions.ConnectTimeout
-        )
+        assert isinstance(exc.value.exc, axonapi.http.requests.exceptions.ConnectTimeout)
 
     def test_connect_error(self):
         """Pass."""

--- a/axonius_api_client/tests/tests_pkg/test_exceptions.py
+++ b/axonius_api_client/tests/tests_pkg/test_exceptions.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from axonius_api_client import exceptions, tools
 
-# FUTURE: Test subclassing/strings/etc
-
 
 class TestKnownCb(object):
     """Test axonius_api_client.tools.join_url."""

--- a/axonius_api_client/tests/tests_pkg/test_http.py
+++ b/axonius_api_client/tests/tests_pkg/test_http.py
@@ -15,6 +15,69 @@ from .. import utils
 
 InsecureRequestWarning = requests.urllib3.exceptions.InsecureRequestWarning
 
+TEST_CLIENT_CERT_NAME = "client_cert.crt"
+TEST_CLIENT_CERT = """
+-----BEGIN CERTIFICATE-----
+MIIEtDCCApygAwIBAgIJAPuK1/Z7X2zbMA0GCSqGSIb3DQEBDQUAMFgxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMRkwFwYDVQQKDBBBeG9uaXVzIENJ
+IFRlc3RzMRkwFwYDVQQDDBBBeG9uaXVzQ0lUZXN0c0NBMB4XDTE5MTIyNDEzMTYx
+NFoXDTM5MDIyMjEzMTYxNFowgYsxCzAJBgNVBAYTAklMMREwDwYDVQQIDAhUZWwg
+QXZpdjEKMAgGA1UEBwwBLjEKMAgGA1UEEQwBLjEQMA4GA1UECgwHQXhvbml1czEM
+MAoGA1UECwwDUiZEMQwwCgYDVQQDDANCb2IxIzAhBgkqhkiG9w0BCQEWFGJvYkBh
+eG9uaXVzdGVzdHMubGFuMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+t/p+x2hlsidVdoDkEnAV7S0t4DTQE4Iir8VGm/Rjb9Gv+O3T/VWPGYYm2roiSS0q
+0DCNOSy8qx28+vccgdPdyflCte9/mas6dTRvXDM3nDLloqI9lQy8Tf1X3rhRDs8a
+EZCmfiATUETPr7vp3+LjriHpSnc/siaUFdDxEWRIbAIR3zNDv7MJD7k16HQCK+5k
+iCtJJXcelYC856vEASORJibUU/Q15KqgegM/ATf6NLem5fYO2dZhQMSj8nW8Cw2Q
+pAo+uUdeDMLscREEG933zH0qDCNaGyjAY7JUqlHXEBtL2GSADNp2WGLyK4xMdTiB
+HqGi05DvFKRXnBvs1YOdnQIDAQABo00wSzAxBgNVHSUEKjAoBggrBgEFBQcDAQYI
+KwYBBQUHAwIGCCsGAQUFBwMDBggrBgEFBQcDBDAJBgNVHRMEAjAAMAsGA1UdDwQE
+AwIF4DANBgkqhkiG9w0BAQ0FAAOCAgEAlyog4NTiu4jvEOisGtm4fWupNBaEC25B
+c9+hntj2454NG3i3s5hkB65A6tFEoWWNSI74CEw/VKzecjqOzAuW4d5qYxA/jtX4
+50Ws0fqzPxKvJTnhzzgOAHpiyxWrJASlp3fhK73Z2aRY6xNr8RoAXsQabj5wU3gm
+kNzUZel5VVcB0Entmjcp2COqIvIm81Wumz+URE732hoC5ZnRDBAlu8zrMqptHU+4
+WBgGBoQUMI3AJcE2UmZlCofsXni+jdr8ZN1j/xbu79W7xCHcQzm3//teWy2KAXp/
+JfFfJ6tkO63hVGV9xGlIC0DK6Z17qy1uEwNKfu2qFvl6msCNT8AeyM5DJwEX//3S
+ITxeZCPzznQx38Hth/ZOuCx5C8FT+mLv8Eoac+bC45HOckCK3wACYIPUCzwSDzxn
+2AWBWP9ltF5/wJu854s23ylJ0Wu2NJArq5vuuA8SSf2Hb4f3Q4J6097iAQ0zunYK
+t06o6EU8iDGxCZ+0Ev1Ocx/6d6wU1W/TBrN1veDQxsd5SQpNc0Q18m5YCcq1yDyt
+DvpaMDAyxvLZtDAfPOd/KgpWUThIcdhAmT+tzde8bTrT306PPzbi5pIgaCsNGBb8
+w4gw3wK/xMly7xZxoLD3YujN/sCcOFY3nhkB+L71GRlX8qYV5uS9fdbTKGZD7SYs
+Ck4QKLYy+P0=
+-----END CERTIFICATE-----
+"""
+
+TEST_CLIENT_KEY_NAME = "client_cert.key"
+TEST_CLIENT_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAt/p+x2hlsidVdoDkEnAV7S0t4DTQE4Iir8VGm/Rjb9Gv+O3T
+/VWPGYYm2roiSS0q0DCNOSy8qx28+vccgdPdyflCte9/mas6dTRvXDM3nDLloqI9
+lQy8Tf1X3rhRDs8aEZCmfiATUETPr7vp3+LjriHpSnc/siaUFdDxEWRIbAIR3zND
+v7MJD7k16HQCK+5kiCtJJXcelYC856vEASORJibUU/Q15KqgegM/ATf6NLem5fYO
+2dZhQMSj8nW8Cw2QpAo+uUdeDMLscREEG933zH0qDCNaGyjAY7JUqlHXEBtL2GSA
+DNp2WGLyK4xMdTiBHqGi05DvFKRXnBvs1YOdnQIDAQABAoIBAGOGeiDrg+AtURlL
+PpYO1n24rBGW4F09UABgKwNg4I30FEsIdV6dc00uekRm3vdRHNEFAtDEN8glzT7C
+gURmVZvWYNVFG3UI4RXYaMmq11GDYyBovgGsow1ZmLheY1MsjACmjLq8JVaN8wAx
+GqLH/b0MkUR8YBPCtOdcYZyz8E2kohvw2P8DBmzUCFXuELHRh5eJ4nRv9ZdF8jw2
+YOYnnBFrWJzE9YA+UCi67oGpMumcu91+tsenc3tvxXJX/HCSBiCc3GEHSROw0SjQ
+TKLLPC+pT5wfmHGFeBPvKFpcfncx50IiTAcnHuBTQJvUvoNkiViBhS5ZG8Pranlq
+w+fBlyECgYEA3wqTnkZFWR6Rl1cSUZRIAeKga380lNcnydhLbmBhiFxr7KoGiuyZ
+cBcGqock0/sng6AwEl9d59ni3I5/2p4DtJmYxx8QU2XmUXSKdGH34qIXL6T27ow0
+292vYIUFAT4vyawkKtO7FlKc+p5frL+dzIDcNOJPj0wfMivRDd33dokCgYEA0yo2
+X9hLqNoq5X+UUVfhlgAswb7wDelx19up3QWX12eRMnwztTp070L/aoMpJaQuXUTC
+HwF4Muffe8XsHMM+n9Jb8SToacspXwF0QrciVVowfdN/tyyP9ZVYzM9jSTm7K0NA
+upfUccDxhgSNv6zNQNKix2qoNIQQuq4OxQpaqXUCgYEAxzmgT/D+wrL+YwtAbqQf
+iaePmVV/dy+T98R+5DGtDOtY74WT4IWkLK40ox+h8sNVMUplhhOvQoiqDk4uv+0C
+7E+CWuJRZ90OVFXf0kMr80DLqyAT/VI5aObkXzeSF+EfOGnNyH9ljnPuiiHq3dgu
+sFut1oMLg7j/6IWg710ETNkCgYEAz/PWMHU1rUeMzw3g5mqBQdNSQErk5Q5sioNM
+uNj1O7BGkU03LtYuqiF0n1QjhWo2Lquz8Azmblti/uVfLMQqPAJRgR0ztFvaljE8
+aScorJ1w+7j5IU7FRriZBrmFsWslI+nLKPa0xIGaWLzLS2PFjnzgyToEBBO61dzr
+tqgHuLECgYBA5nJsbMc36x55d61/4XLkX4Pmoh/LtTEZt9LyoWXUOq86vZuP1W/u
+fcCY7mv+lRAoiAC1Z38YjGgJmZINH9EoaVnZJNeaO/86qemnlwYQ5/DIViycPZWI
+oXO3sikOr2yrDS95jHjVzU0iW3xzu8bM9D01swBx0T5kYKWZo4ywpQ==
+-----END RSA PRIVATE KEY-----
+"""
+
 
 class TestParserUrl(object):
     """Test axonapi.http.ParserUrl."""
@@ -167,6 +230,46 @@ class TestHttp(object):
         response = http()
 
         assert response in http._HISTORY
+
+    def test_client_cert_missing_one(self, request, tmp_path):
+        """Test cert or key supplied, but not the other."""
+        ax_url = utils.get_url(request)
+        test_path = tmp_path / TEST_CLIENT_CERT_NAME
+        test_path.write_text(TEST_CLIENT_CERT)
+
+        with pytest.raises(exceptions.HttpError):
+            axonapi.Http(url=ax_url, cert_client_cert=test_path, certwarn=False)
+
+        with pytest.raises(exceptions.HttpError):
+            axonapi.Http(url=ax_url, cert_client_key=test_path, certwarn=False)
+
+    def test_client_cert_seperate(self, request, tmp_path):
+        """Test cert or key supplied, but not the other."""
+        ax_url = utils.get_url(request)
+        cert_path = tmp_path / TEST_CLIENT_CERT_NAME
+        cert_path.write_text(TEST_CLIENT_CERT)
+        key_path = tmp_path / TEST_CLIENT_KEY_NAME
+        key_path.write_text(TEST_CLIENT_KEY)
+
+        http = axonapi.Http(
+            url=ax_url,
+            cert_client_cert=cert_path,
+            cert_client_key=key_path,
+            certwarn=False,
+        )
+
+        http()
+
+    def test_client_cert_both(self, request, tmp_path):
+        """Test cert or key supplied, but not the other."""
+        ax_url = utils.get_url(request)
+        both_path = tmp_path / TEST_CLIENT_CERT_NAME
+        both_cert = "{}\n{}\n".format(TEST_CLIENT_CERT, TEST_CLIENT_KEY)
+        both_path.write_text(both_cert)
+
+        http = axonapi.Http(url=ax_url, cert_client_both=both_path, certwarn=False)
+
+        http()
 
     def test_log_req_attrs_true(self, request, caplog):
         """Test verbose logging of request attrs when log_request_attrs=True."""

--- a/axonius_api_client/tests/tests_pkg/test_http.py
+++ b/axonius_api_client/tests/tests_pkg/test_http.py
@@ -130,9 +130,7 @@ class TestHttp(object):
 
         http()
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 6), reason="requires python3.6 or higher"
-    )
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_verify_ca_bundle(self, request, httpbin_secure, httpbin_ca_bundle):
         """Test quiet_urllib=False no warning from urllib3 when using ca bundle."""
         url = httpbin_secure.url

--- a/axonius_api_client/tests/tests_pkg/test_tools.py
+++ b/axonius_api_client/tests/tests_pkg/test_tools.py
@@ -27,6 +27,7 @@ class TestCoerce(object):
         assert tools.coerce_bool("y") is True
         assert tools.coerce_bool("yes") is True
         assert tools.coerce_bool("true") is True
+        assert tools.coerce_bool("True") is True
         assert tools.coerce_bool("1") is True
         assert tools.coerce_bool(1) is True
         assert tools.coerce_bool("t") is True
@@ -34,6 +35,7 @@ class TestCoerce(object):
         assert tools.coerce_bool("n") is False
         assert tools.coerce_bool("no") is False
         assert tools.coerce_bool("false") is False
+        assert tools.coerce_bool("False") is False
         assert tools.coerce_bool("0") is False
         assert tools.coerce_bool(0) is False
         assert tools.coerce_bool("f") is False

--- a/axonius_api_client/tests/tests_pkg/test_tools.py
+++ b/axonius_api_client/tests/tests_pkg/test_tools.py
@@ -244,7 +244,6 @@ class TestPathWrite(object):
         assert ret_path.read_text() == data
         assert format(ret_path) == format(path)
         assert ret_write == len(data)
-        # FUTURE: not the same octal on windows
         assert ret_path.stat().st_mode == 33152
         assert ret_path.parent.stat().st_mode == 16832
 

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -83,7 +83,7 @@ def coerce_bool(obj):
     coerce_obj = obj
 
     if isinstance(obj, STR):
-        coerce_obj.lower().strip()
+        coerce_obj = coerce_obj.lower().strip()
 
     if coerce_obj in YES:
         return True

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -2,7 +2,7 @@
 """Version information for this package."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"
 VERSION = __version__
 """:obj:`str`: Version of package."""
 

--- a/axonshell_manual.py
+++ b/axonshell_manual.py
@@ -14,6 +14,9 @@ if __name__ == "__main__":
     AX_URL = os.environ["AX_URL"]
     AX_KEY = os.environ["AX_KEY"]
     AX_SECRET = os.environ["AX_SECRET"]
+    AX_CLIENT_CERT_BOTH = os.environ.get("AX_CLIENT_CERT_BOTH", None) or None
+    AX_CLIENT_CERT_CERT = os.environ.get("AX_CLIENT_CERT_CERT", None) or None
+    AX_CLIENT_CERT_KEY = os.environ.get("AX_CLIENT_CERT_KEY", None) or None
 
     def jdump(obj, **kwargs):
         """JSON dump utility."""
@@ -24,6 +27,9 @@ if __name__ == "__main__":
         key=AX_KEY,
         secret=AX_SECRET,
         certwarn=False,
+        cert_client_both=AX_CLIENT_CERT_BOTH,
+        cert_client_cert=AX_CLIENT_CERT_CERT,
+        cert_client_key=AX_CLIENT_CERT_KEY,
         log_level_console="debug",
         log_level_api="debug",
         log_console=True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,11 +19,6 @@ Resources:
 * `PyPi package listing`_
 * `GitHub repository`_
 
-.. note::
-
-   This documentation is still in the midst of being re-worked to match the 2.0 release.
-   Additional usage examples and other updates should come just about every day.
-
 Table of Contents
 ###############################################
 

--- a/docs/main/install.rst
+++ b/docs/main/install.rst
@@ -17,7 +17,7 @@ the PATH after you install it.
 
 .. note::
 
-   While 2.7 is supported, using it is not recommended due to the `pending EOL on January 1st 2020 <pyeol>`_.
+   While 2.7 is supported, using it is not recommended due to the `EOL on January 1st 2020 <pyeol>`_.
 
 Install the package using `pip`_
 ============================================================

--- a/docs/main/releases.rst
+++ b/docs/main/releases.rst
@@ -19,31 +19,23 @@ Minor releases: 1.x.0:
 Major releases: x.0.0:
     A major release is only done for architectural and model changes to the API client library.
 
-    Any scripts that utilize this API library will probably not work with new major releases.
-
-Todo
-==================================================
-
-2.0.1
---------------------------------------------------
-* :green:`docs`: Finish re-doing all command line interface docstrings.
-* :green:`docs`: Add rough command line interface examples.
-* :green:`docs`: Add rough API examples.
-
-2.0.2
---------------------------------------------------
-* :green:`docs`: Flush out the rest of the command line interface examples.
-* :green:`docs`: Flush out the rest of the API examples.
-* :green:`docs`: Finish re-doing all doc strings.
-
-
-2.1.0
---------------------------------------------------
-* :blue:`api`: api.Enforcements flush out.
-* :blue:`rest_api`: Flush out enforcement routes in REST API server.
+    Any scripts that utilize this API library might not work with new major releases.
 
 Changelog
 ==================================================
+
+`2.1.4`_ (2020-01-12)
+--------------------------------------------------
+* :red:`bugfix`: Fixed a minor issue with text string 'False' not being recognized as an alternative for boolean False.
+* :red:`bugfix`: Fixed a minor issue with selecting an adapter connection by ID.
+* :blue:`enhancement`: You can now specify fields to fetch in addition to the fields defined in a saved-query. References:
+  * :ref:`fr_214_5`
+* :blue:`enhancement`: You can now specify fields using regular expressions whereever fields can be specified. References:
+  * :ref:`fr_214_3`
+  * :ref:`fr_214_4`
+* :blue:`enhancement`: You can use show-config when adding new connections to see the configuration without being prompted. References:
+  * :ref:`fr_214_1`
+  * :ref:`fr_214_2`
 
 `2.0.0`_ (2019-09-16)
 --------------------------------------------------
@@ -58,3 +50,4 @@ Changelog
 
 .. _1.0.0: https://github.com/Axonius/axonius_api_client/releases/tag/1.0.0
 .. _2.0.0: https://github.com/Axonius/axonius_api_client/releases/tag/2.0.0
+.. _2.1.4: https://github.com/Axonius/axonius_api_client/releases/tag/2.1.4

--- a/docs/main/releases.rst
+++ b/docs/main/releases.rst
@@ -29,11 +29,16 @@ Changelog
 * :red:`bugfix`: Fixed a minor issue with text string 'False' not being recognized as an alternative for boolean False.
 * :red:`bugfix`: Fixed a minor issue with selecting an adapter connection by ID.
 * :blue:`enhancement`: You can now specify fields to fetch in addition to the fields defined in a saved-query. References:
+
   * :ref:`fr_214_5`
+
 * :blue:`enhancement`: You can now specify fields using regular expressions whereever fields can be specified. References:
+
   * :ref:`fr_214_3`
   * :ref:`fr_214_4`
+
 * :blue:`enhancement`: You can use show-config when adding new connections to see the configuration without being prompted. References:
+
   * :ref:`fr_214_1`
   * :ref:`fr_214_2`
 

--- a/docs/main/usage_api.rst
+++ b/docs/main/usage_api.rst
@@ -10,4 +10,6 @@ API Usage
 
 .. todo::
 
-   The API reference docs are not done yet. The CLI usage docs will be finished first.
+   The API library documentation and examples need to be flushed out, but time
+   constraints have not allowed for this to happen. If help is needed in utilizing this
+   API library, please contact apiclient@axonius.com.

--- a/docs/main/usage_cli/common_examples/select_field_examples/ex7.rst
+++ b/docs/main/usage_cli/common_examples/select_field_examples/ex7.rst
@@ -5,6 +5,9 @@
 Select Fields: Using Regular Expressions Case 1
 ###############################################
 
+.. note::
+   :blue:`added in 2.1.4`
+
 This does the following:
 
 * Get device assets and include the generic field ``os.type``. Also include all fields

--- a/docs/main/usage_cli/common_examples/select_field_examples/ex7.rst
+++ b/docs/main/usage_cli/common_examples/select_field_examples/ex7.rst
@@ -1,0 +1,31 @@
+.. include:: /main/.special.rst
+
+.. _fr_214_3:
+
+Select Fields: Using Regular Expressions Case 1
+###############################################
+
+This does the following:
+
+* Get device assets and include the generic field ``os.type``. Also include all fields
+  that match ``hostname`` from adapters matching ``.`` (which would match all adapters).
+
+.. code:: shell
+
+   $ axonshell devices get \
+     -f os.type \
+     -fr '.:hostname'
+     --export-file device.json \
+     --export-overwrite
+
+.. raw:: html
+
+    <script id="asciicast-293193" src="https://asciinema.org/a/293193.js" async></script>
+
+.. note::
+
+    If no adapter is supplied (i.e. just ``hostname`` instead of
+    ``adapter_regex:hostname``), the assumed default will be ``.`` (which would match
+    all adapters).
+
+.. include:: notes.rst

--- a/docs/main/usage_cli/common_examples/select_field_examples/ex8.rst
+++ b/docs/main/usage_cli/common_examples/select_field_examples/ex8.rst
@@ -5,6 +5,9 @@
 Select Fields: Using Regular Expressions Case 2
 ###############################################
 
+.. note::
+   :blue:`added in 2.1.4`
+
 This does the following:
 
 * Get device assets and include the generic field ``os.type``. Also include all fields

--- a/docs/main/usage_cli/common_examples/select_field_examples/ex8.rst
+++ b/docs/main/usage_cli/common_examples/select_field_examples/ex8.rst
@@ -1,0 +1,31 @@
+.. include:: /main/.special.rst
+
+.. _fr_214_4:
+
+Select Fields: Using Regular Expressions Case 2
+###############################################
+
+This does the following:
+
+* Get device assets and include the generic field ``os.type``. Also include all fields
+  that contain ``name`` from adapters matching ``generic`` (aka the aggregated data).
+
+.. code:: shell
+
+   $ axonshell devices get \
+     --field os.type \
+     --field-regex 'generic:name' \
+     --export-file device.json \
+     --export-overwrite
+
+.. raw:: html
+
+    <script id="asciicast-293194" src="https://asciinema.org/a/293194.js" async></script>
+
+.. note::
+
+    If no adapter is supplied (i.e. just ``hostname`` instead of
+    ``adapter_regex:hostname``), the assumed default will be ``.`` (which would match
+    all adapters).
+
+.. include:: notes.rst

--- a/docs/main/usage_cli/common_examples/select_field_examples/notes.rst
+++ b/docs/main/usage_cli/common_examples/select_field_examples/notes.rst
@@ -6,8 +6,7 @@ Notes
 .. note::
 
    This example uses the ``devices get`` command, but it will work for any
-   ``get..`` command for the devices or users command groups with the exception of
-   ``get-by-saved-query`` (which uses the fields built in to the saved query).
+   ``get..`` command for the devices or users command groups.
 
 .. note::
 
@@ -22,4 +21,4 @@ Notes
 .. note::
 
    Generic fields are the fields that are under the ``General`` section in the GUI.
-   These are the fields that contain all of the correlated data for an asset.
+   These are the fields that contain all of the aggregated data for an asset.

--- a/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.rst
+++ b/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.rst
@@ -5,6 +5,9 @@
 Show the settings needed for a connection in text format
 ########################################################
 
+.. note::
+   :blue:`added in 2.1.4`
+
 This can be used to show the connection settings needed so you can build a command line
 that contains all the necessary settings using ``--config setting_name=setting_value``
 

--- a/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.rst
+++ b/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.rst
@@ -1,0 +1,18 @@
+.. include:: /main/.special.rst
+
+.. _fr_214_1:
+
+Show the settings needed for a connection in text format
+########################################################
+
+This can be used to show the connection settings needed so you can build a command line
+that contains all the necessary settings using ``--config setting_name=setting_value``
+
+.. code:: shell
+
+   $ axonshell adapters cnx add --adapter csv --show-config text
+
+.. raw:: html
+
+    <script id="asciicast-293198" src="https://asciinema.org/a/293198.js" async></script>
+

--- a/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex4.rst
+++ b/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex4.rst
@@ -1,0 +1,17 @@
+.. include:: /main/.special.rst
+
+.. _fr_214_2:
+
+Show the settings needed for a connection in json format
+########################################################
+
+This can be used to show the connection settings needed so you can build a command line
+that contains all the necessary settings using ``--config setting_name=setting_value``
+
+.. code:: shell
+
+   $ axonshell adapters cnx add --adapter csv --show-config json
+
+.. raw:: html
+
+    <script id="asciicast-293199" src="https://asciinema.org/a/293199.js" async></script>

--- a/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex4.rst
+++ b/docs/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex4.rst
@@ -5,6 +5,9 @@
 Show the settings needed for a connection in json format
 ########################################################
 
+.. note::
+   :blue:`added in 2.1.4`
+
 This can be used to show the connection settings needed so you can build a command line
 that contains all the necessary settings using ``--config setting_name=setting_value``
 

--- a/docs/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.rst
+++ b/docs/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.rst
@@ -24,9 +24,10 @@ Common Options
 
 * :ref:`connection_options` for examples of supplying the Axonius credentials and URL.
 * :ref:`export_options` for examples of exporting data in different formats and outputs.
-* :ref:`select_fields_ex` for examples of selecting which fields (columns) to include
-  in the response. The fields you supply for get-by-saved-query will be appended to the
-  fields specified inside of the saved query.
+* :ref:`select_fields_ex` for examples of selecting which fields
+  (columns) to include in the response. The fields you supply for get-by-saved-query
+  will be appended to the fields specified inside of the saved query.
+  (:blue:`added in 2.1.4`)
 
 Examples
 ===============================================

--- a/docs/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.rst
+++ b/docs/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.rst
@@ -17,11 +17,16 @@ The output from this command is able to be supplied as input to these commands:
 * :doc:`../grp_objects_labels_cmds/cmd_remove` to remove labels from all assets returned
   from this command.
 
+.. _fr_214_5:
+
 Common Options
 ===============================================
 
 * :ref:`connection_options` for examples of supplying the Axonius credentials and URL.
 * :ref:`export_options` for examples of exporting data in different formats and outputs.
+* :ref:`select_fields_ex` for examples of selecting which fields (columns) to include
+  in the response. The fields you supply for get-by-saved-query will be appended to the
+  fields specified inside of the saved query.
 
 Examples
 ===============================================

--- a/examples/cvss_filtering.py
+++ b/examples/cvss_filtering.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python -i
+# -*- coding: utf-8 -*-
+"""Example script for devices with vulnerable software with min/max CVSS score."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+def jdump(obj, **kwargs):
+    """JSON dump utility."""
+    print(axonapi.tools.json_reload(obj, **kwargs))
+
+
+def get_dvcs_with_cves(dvcs):
+    """Get only the devices that have vulnerable sw info."""
+    return [x for x in dvcs if x.get("specific_data.data.software_cves")]
+
+
+def filter_cvss(dvcs, cvss_min, cvss_max):
+    """Get only devices with vuln sw with cvss score in between min/max."""
+    for dvc in dvcs:
+        new_dvc = dvc.copy()
+        vuln_sws = dvc.get("specific_data.data.software_cves", [])
+        new_dvc["found_vuln"] = []
+        for vuln_sw in vuln_sws:
+            cvss = vuln_sw.get("cvss", 0.0)
+            if cvss_min <= cvss <= cvss_max and vuln_sw not in new_dvc["found_vuln"]:
+                new_dvc["found_vuln"].append(vuln_sw)
+        if new_dvc["found_vuln"]:
+            yield new_dvc
+
+
+def dump_cves(dvcs, dvc_keys, sw_keys):
+    """Report printer."""
+    ktmpl = "{s}{k}: {v}".format
+    dvcs = [x for x in dvcs if x.get("found_vuln", [])]
+    for dvc in dvcs:
+        found_vuln = dvc.get("found_vuln", [])
+        found_vuln = sorted(found_vuln, key=lambda x: x["cvss"], reverse=True)
+        print("*" * 80)
+        items = {k: v for k, v in dvc.items() if k in dvc_keys}
+        for k, v in items.items():
+            print(ktmpl(s=" " * 4, k=k, v=v))
+        for sw in found_vuln:
+            print("-" * 80)
+            sw_items = {k: v for k, v in sw.items() if k in sw_keys}
+            for k, v in sw_items.items():
+                print(ktmpl(s=" " * 8, k=k, v=v))
+
+
+if __name__ == "__main__":
+    import os
+
+    import axonius_api_client as axonapi
+
+    tools = axonapi.tools
+    axonapi.cli.cli_constants.load_dotenv()
+
+    AX_URL = os.environ["AX_URL"]
+    AX_KEY = os.environ["AX_KEY"]
+    AX_SECRET = os.environ["AX_SECRET"]
+
+    ctx = axonapi.Connect(
+        url=AX_URL,
+        key=AX_KEY,
+        secret=AX_SECRET,
+        certwarn=False,
+        log_level_console="debug",
+        log_level_api="debug",
+        log_console=False,
+    )
+
+    ctx.start()
+
+    devices = ctx.devices
+    users = ctx.users
+    adapters = ctx.adapters
+
+    QUERY = None
+    FIELDS = ["software_cves"]
+    CVSS_MIN = 6.0
+    CVSS_MAX = 10.0
+    DUMP_DVC_KEYS = [
+        "specific_data.data.hostname",
+        "specific_data.data.name",
+        "specific_data.data.network_interfaces.ips",
+        "internal_axon_id",
+    ]
+    DUMP_SW_KEYS = [
+        "cve_id",
+        "cve_severity",
+        "cvss",
+        "software_name",
+        "software_vendor",
+    ]
+
+    dvcs = devices.get(query=QUERY, fields=FIELDS)
+
+    dvcs_with_cves = get_dvcs_with_cves(dvcs=dvcs)
+
+    dvcs_cvss_minmax = list(
+        filter_cvss(dvcs=dvcs_with_cves, cvss_min=CVSS_MIN, cvss_max=CVSS_MAX)
+    )
+
+    dump_cves(dvcs=dvcs_cvss_minmax, dvc_keys=DUMP_DVC_KEYS, sw_keys=DUMP_SW_KEYS)

--- a/examples/get_by_sq.py
+++ b/examples/get_by_sq.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python -i
+# -*- coding: utf-8 -*-
+"""Example of getting devices by a saved query."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+if __name__ == "__main__":
+    import os
+    import json
+
+    import axonius_api_client as axonapi
+
+    tools = axonapi.tools
+    axonapi.cli.cli_constants.load_dotenv()
+
+    AX_URL = os.environ["AX_URL"]
+    AX_KEY = os.environ["AX_KEY"]
+    AX_SECRET = os.environ["AX_SECRET"]
+    SQ_NAME = os.environ.get("AX_SQ_NAME", "Managed Devices")
+    FORMAT = os.environ.get("AX_FORMAT", "json")
+
+    def jdump(obj, **kwargs):
+        """JSON dump utility."""
+        print(axonapi.tools.json_reload(obj, **kwargs))
+
+    ctx = axonapi.Connect(
+        url=AX_URL,
+        key=AX_KEY,
+        secret=AX_SECRET,
+        certwarn=False,
+        log_level_console="debug",
+        log_level_api="debug",
+        log_console=True,
+    )
+
+    ctx.start()
+
+    devices = ctx.devices
+    users = ctx.users
+    adapters = ctx.adapters
+
+    results = devices.get_by_saved_query(name=SQ_NAME)
+
+    if FORMAT.lower() == "json":
+        export_results = json.dumps(results, indent=4)
+    elif FORMAT.lower() == "csv":
+        joiner = "\n"  # join multiple items in inner cell with this character
+        export_results = axonapi.cli.serial.obj_to_csv(
+            ctx=None, raw_data=results, joiner=joiner,
+        )
+
+    else:
+        msg = "Invalid format {}, must be one of 'json' or 'csv'".format(FORMAT)
+        raise Exception(msg)


### PR DESCRIPTION

## 2.1.4

Release date: 2020-01-12

### Bug fixes

* Fixed a minor issue with text string 'False' not being recognized as
  an alternative for boolean False.
* Fixed a minor issue with selecting an adapter connection by ID.

### Enhancements

* You can now specify fields to fetch in addition to the fields defined in a
  saved-query. References:
  * [Common Options for get-by-saved-query](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/grp_objects_cmds/cmd_get_by_saved_query.html#fr-214-5)
* You can now specify fields using regular expressions whereever fields can
  be specified.
  * [Select Fields: Using Regular Expressions Case 1](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/common_examples/select_field_examples/ex7.html#fr-214-3)
  * [Select Fields: Using Regular Expressions Case 2](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/common_examples/select_field_examples/ex8.html#fr-214-4)
* You can use show-config when adding new connections to see the configuration without
  being prompted.
  * [Show the settings needed for a connection in text format](https://axonius-api-client.readthedocs.io/en/latest/main/usage_cli/grp_cnx_cmds/cmd_add_examples/ex3.html#fr-214-1)
