### PR TITLE
4.10.7

### DIFF
--- a/axonius_api_client/api/assets/asset_mixin.py
+++ b/axonius_api_client/api/assets/asset_mixin.py
@@ -336,8 +336,9 @@ class AssetMixin(ModelMixins):
                 state = page.process_page(state=state, start_dt=start_dt, apiobj=self)
 
                 for row in page.assets:
+                    state = page.start_row(state=state, apiobj=self, row=row)
                     yield from listify(obj=callbacks.process_row(row=row))
-                    state = page.process_row(state=state, apiobj=self)
+                    state = page.process_row(state=state, apiobj=self, row=row)
 
                 state = page.process_loop(state=state, apiobj=self)
 

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -282,8 +282,10 @@ class SavedQuery(ChildMixins):
         data_view["sort"] = data_sort
         data_view["fields"] = fields
         data_view["pageSize"] = gui_page_size
-        data_view["colFilters"] = data_column_filters or {}
-        data_view["colExcludedAdapters"] = {}  # TBD
+        # 4.5 SEMI_BREAKING_CHANGE: now a list of dict
+        data_view["colFilters"] = listify(data_column_filters or {})
+        # 4.5 SEMI_BREAKING_CHANGE: now a list of dict
+        data_view["colExcludedAdapters"] = listify({})  # TBD
 
         # data = {}
         # data["name"] = name

--- a/axonius_api_client/api/json_api/__init__.py
+++ b/axonius_api_client/api/json_api/__init__.py
@@ -1,27 +1,10 @@
 # -*- coding: utf-8 -*-
 """Models for API requests & responses."""
 
-from . import (
-    adapters,
-    assets,
-    audit_logs,
-    base,
-    central_core,
-    custom_fields,
-    enforcements,
-    generic,
-    instances,
-    lifecycle,
-    password_reset,
-    remote_support,
-    resources,
-    saved_queries,
-    signup,
-    system_meta,
-    system_roles,
-    system_settings,
-    system_users,
-)
+from . import (adapters, assets, audit_logs, base, central_core, custom_fields,
+               enforcements, generic, instances, lifecycle, password_reset,
+               remote_support, resources, saved_queries, signup, system_meta,
+               system_roles, system_settings, system_users)
 
 __all__ = (
     "base",

--- a/axonius_api_client/api/json_api/system_roles.py
+++ b/axonius_api_client/api/json_api/system_roles.py
@@ -98,40 +98,7 @@ class SystemRoleSchema(BaseSchemaJson):
     permissions = marshmallow_jsonapi.fields.Dict()
     predefined = SchemaBool(default=False)
     last_updated = SchemaDatetime(allow_none=True)
-    data_scope_restriction = marshmallow_jsonapi.fields.Dict(required=False)
-    """ 4.5 BREAKING_CHANGE
-
-    asset_scope_restriction -> data_scope_restriction
-
-    URL: 'https://10.20.2.196:443/api/V4.0/settings/roles', METHOD: POST
-    CODE: 400, REASON: 'BAD REQUEST', BYTES OUT: 135, BYTES IN: 148
-
-    Request Object:
-    {
-      "data": {
-        "type": "roles_schema",
-        "attributes": {
-          "name": "badwolf",
-          "permissions": {},
-          "asset_scope_restriction": {
-            "enabled": false
-          }
-        }
-      }
-    }
-    Response Object:
-
-    -----
-    - status:
-       error
-    - type:
-       KeyError
-    - message:
-       An error occurred. Please contact Axonius support.
-       AX-ID: 8fb9e953-281a-4d4f-81ce-1e874d2c890f
-
-    Response has a bad HTTP status code 400
-    """
+    asset_scope_restriction = marshmallow_jsonapi.fields.Dict(required=False)
     # PBUG: not modeled well
 
     # NEW_IN: 05/31/21 cortex/develop
@@ -157,9 +124,9 @@ class SystemRoleUpdateSchema(SystemRoleSchema):
     @marshmallow.post_load
     def post_load_fixit(self, data: dict, **kwargs) -> dict:
         """Pass."""
-        asr = data.get("data_scope_restriction", {}) or {}
+        asr = data.get("asset_scope_restriction", {}) or {}
         if not asr:
-            data["data_scope_restriction"] = {"enabled": False}
+            data["asset_scope_restriction"] = {"enabled": False}
         return data
 
     @marshmallow.post_dump
@@ -174,9 +141,9 @@ class SystemRoleUpdateSchema(SystemRoleSchema):
         # NEW_IN: 05/31/21 cortex/develop
         data.pop("users_count", None)
 
-        asr = data.get("data_scope_restriction", {}) or {}
+        asr = data.get("asset_scope_restriction", {}) or {}
         if not asr:
-            data["data_scope_restriction"] = asr = {"enabled": False}
+            data["asset_scope_restriction"] = asr = {"enabled": False}
         asr.pop("asset_scope", None)
         # PBUG: ASR seems to be quite poorly modeled
         return data
@@ -195,7 +162,7 @@ class SystemRole(BaseModel):
     name: str
     uuid: str
 
-    data_scope_restriction: Optional[dict] = dataclasses.field(default_factory=dict)
+    asset_scope_restriction: Optional[dict] = dataclasses.field(default_factory=dict)
     predefined: bool = False
     permissions: dict = dataclasses.field(default_factory=dict)
     last_updated: Optional[datetime.datetime] = get_field_dc_mm(
@@ -215,8 +182,8 @@ class SystemRole(BaseModel):
         """Pass."""
         if self.id is None and self.uuid is not None:
             self.id = self.uuid
-        if not self.data_scope_restriction:
-            self.data_scope_restriction = {"enabled": False}
+        if not self.asset_scope_restriction:
+            self.asset_scope_restriction = {"enabled": False}
         # PBUG: ASR seems to be quite poorly modeled
 
     def to_dict_old(self):
@@ -273,7 +240,7 @@ class SystemRoleCreateSchema(BaseSchemaJson):
 
     name = marshmallow_jsonapi.fields.Str(required=True)
     permissions = marshmallow_jsonapi.fields.Dict(required=True)
-    data_scope_restriction = marshmallow_jsonapi.fields.Dict(required=False)
+    asset_scope_restriction = marshmallow_jsonapi.fields.Dict(required=False)
 
     @staticmethod
     def get_model_cls() -> type:
@@ -288,18 +255,18 @@ class SystemRoleCreateSchema(BaseSchemaJson):
     @marshmallow.post_load
     def post_load_fixit(self, data: dict, **kwargs) -> dict:
         """Pass."""
-        asr = data.get("data_scope_restriction", {}) or {}
+        asr = data.get("asset_scope_restriction", {}) or {}
         if not asr:
-            data["data_scope_restriction"] = {"enabled": False}
+            data["asset_scope_restriction"] = {"enabled": False}
         # PBUG: ASR seems to be quite poorly modeled
         return data
 
     @marshmallow.post_dump
     def post_dump_fixit(self, data: dict, **kwargs) -> dict:
         """Pass."""
-        asr = data.get("data_scope_restriction", {}) or {}
+        asr = data.get("asset_scope_restriction", {}) or {}
         if not asr:
-            data["data_scope_restriction"] = asr = {"enabled": False}
+            data["asset_scope_restriction"] = asr = {"enabled": False}
         asr.pop("asset_scope", None)
         # PBUG: ASR seems to be quite poorly modeled
         return data
@@ -311,7 +278,7 @@ class SystemRoleCreate(BaseModel):
 
     name: str
     permissions: dict
-    data_scope_restriction: Optional[dict] = dataclasses.field(default_factory=dict)
+    asset_scope_restriction: Optional[dict] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
@@ -320,6 +287,6 @@ class SystemRoleCreate(BaseModel):
 
     def __post_init__(self):
         """Pass."""
-        if not self.data_scope_restriction:
-            self.data_scope_restriction = {"enabled": False}
+        if not self.asset_scope_restriction:
+            self.asset_scope_restriction = {"enabled": False}
         # PBUG: ASR seems to be quite poorly modeled

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -173,6 +173,7 @@ class Formats(BaseEnum):
     ip_preferred = enum.auto()
     os_distribution = "os-distribution"
     dynamic_field = enum.auto()
+    date = enum.auto()  # added 4.5
 
 
 @dataclasses.dataclass
@@ -518,6 +519,20 @@ class OperatorTypeMaps(BaseData):
         ],
         field_type=Types.string,
         field_format=Formats.datetime,
+    )
+    string_date: OperatorTypeMap = OperatorTypeMap(
+        name="string_date",
+        operators=[
+            Operators.exists,
+            Operators.less_than_date,
+            Operators.more_than_date,
+            Operators.last_hours,
+            Operators.next_hours,
+            Operators.last_days,
+            Operators.next_days,
+        ],
+        field_type=Types.string,
+        field_format=Formats.date,
     )
     string_image: OperatorTypeMap = OperatorTypeMap(
         name="string_image",

--- a/axonius_api_client/tests/meta.py
+++ b/axonius_api_client/tests/meta.py
@@ -86,6 +86,7 @@ FIELD_FORMATS = [
     "time",
     "version",
     "dynamic_field",  # ~3.13
+    "date",  # 4.5
 ]
 SCHEMA_FIELD_FORMATS = FIELD_FORMATS
 SCHEMA_TYPES = ["string", "bool", "array", "integer", "number", "file"]

--- a/axonius_api_client/tests/tests_api/tests_assets/test_fields.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_fields.py
@@ -89,7 +89,14 @@ class FieldsPrivate:
             assert isinstance(description, str)
 
             sort = field.pop("sort", False)
-            assert isinstance(sort, bool)
+            if isinstance(sort, dict):
+                sort_desc = sort.pop("desc")
+                assert isinstance(sort_desc, bool)
+                sort_field = sort.pop("field")
+                assert isinstance(sort_field, str)
+                assert not sort
+            else:
+                assert isinstance(sort, bool)
 
             unique = field.pop("unique", False)
             assert isinstance(unique, bool)
@@ -129,6 +136,13 @@ class FieldsPrivate:
             # 4.3
             are_values_cached = field.pop("are_values_cached", False)
             assert isinstance(are_values_cached, bool)
+
+            # 4.5
+            parse_json_attrs = field.pop("parse_json_attrs", False)
+            assert isinstance(parse_json_attrs, bool)
+
+            show_all_results = field.pop("show_all_results", False)
+            assert isinstance(show_all_results, bool)
 
             val_source(obj=field)
 
@@ -192,6 +206,13 @@ class FieldsPrivate:
             # 4.3
             are_values_cached = items.pop("are_values_cached", False)
             assert isinstance(are_values_cached, bool)
+
+            # 4.5
+            parse_json_attrs = items.pop("parse_json_attrs", False)
+            assert isinstance(parse_json_attrs, bool)
+
+            show_all_results = items.pop("show_all_results", False)
+            assert isinstance(show_all_results, bool)
 
             assert not items, list(items)
 
@@ -287,7 +308,14 @@ class FieldsPublic:
         assert isinstance(description, str)
 
         sort = schema.pop("sort", False)
-        assert isinstance(sort, bool)
+        if isinstance(sort, dict):
+            sort_desc = sort.pop("desc")
+            assert isinstance(sort_desc, bool)
+            sort_field = sort.pop("field")
+            assert isinstance(sort_field, str)
+            assert not sort
+        else:
+            assert isinstance(sort, bool)
 
         unique = schema.pop("unique", False)
         assert isinstance(unique, bool)
@@ -344,6 +372,13 @@ class FieldsPublic:
         are_values_cached = schema.pop("are_values_cached", False)
         assert isinstance(are_values_cached, bool)
 
+        # 4.5
+        parse_json_attrs = schema.pop("parse_json_attrs", False)
+        assert isinstance(parse_json_attrs, bool)
+
+        show_all_results = schema.pop("show_all_results", False)
+        assert isinstance(show_all_results, bool)
+
         if is_complex:
             if name != "all":
                 assert sub_fields
@@ -381,6 +416,13 @@ class FieldsPublic:
             # 4.3
             are_values_cached = items.pop("are_values_cached", False)
             assert isinstance(are_values_cached, bool)
+
+            # 4.5
+            parse_json_attrs = items.pop("parse_json_attrs", False)
+            assert isinstance(parse_json_attrs, bool)
+
+            show_all_results = items.pop("show_all_results", False)
+            assert isinstance(show_all_results, bool)
 
             assert not items
 

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -307,11 +307,11 @@ def validate_sq(asset):
     assert isinstance(updated_by_deleted, bool)
 
     # 4.5
-    updated_by_is_first_login = updated_by.pop("is_first_login")
+    updated_by_is_first_login = updated_by.pop("is_first_login", False)
     assert isinstance(updated_by_is_first_login, bool)
 
     # 4.5
-    updated_by_permanent = updated_by.pop("permanent")
+    updated_by_permanent = updated_by.pop("permanent", False)
     assert isinstance(updated_by_permanent, bool)
 
     updated_str_keys_req = [

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -5,7 +5,6 @@ import datetime
 import json
 
 import pytest
-
 from axonius_api_client.api import json_api
 from axonius_api_client.constants.api import GUI_PAGE_SIZES
 from axonius_api_client.constants.general import SIMPLE
@@ -96,7 +95,7 @@ class SavedQueryPublic:
         fields = ["adapters", "last_seen", "id", field_simple]
 
         sort_field = field_simple
-        colfilters = {field_simple: "a"}
+        # colfilters = {field_simple: "a"}
         sort_desc = False
         gui_page_size = GUI_PAGE_SIZES[-1]
         tags = ["badwolf1", "badwolf2"]
@@ -113,7 +112,7 @@ class SavedQueryPublic:
             fields=fields,
             sort_field=sort_field,
             sort_descending=sort_desc,
-            column_filters=colfilters,
+            # column_filters=colfilters,
             gui_page_size=gui_page_size,
             tags=tags,
             description=description,
@@ -130,7 +129,7 @@ class SavedQueryPublic:
         assert row["view"]["query"]["onlyExpressionsFilter"] == query
         assert row["view"]["query"]["expressions"] == []
         assert row["view"]["pageSize"] == gui_page_size
-        assert row["view"]["colFilters"] == colfilters
+        # assert row["view"]["colFilters"] == colfilters
         assert row["view"]["sort"]["field"] == sort_field
         assert row["view"]["sort"]["desc"] == sort_desc
 
@@ -307,6 +306,14 @@ def validate_sq(asset):
     updated_by_deleted = updated_by.pop("deleted")
     assert isinstance(updated_by_deleted, bool)
 
+    # 4.5
+    updated_by_is_first_login = updated_by.pop("is_first_login")
+    assert isinstance(updated_by_is_first_login, bool)
+
+    # 4.5
+    updated_by_permanent = updated_by.pop("permanent")
+    assert isinstance(updated_by_permanent, bool)
+
     updated_str_keys_req = [
         "first_name",
         "last_name",
@@ -375,11 +382,52 @@ def validate_sq(asset):
     query = view.pop("query")
     assert isinstance(query, dict)
 
+    """ changed in 4.5
     colfilters = view.pop("colFilters", {})
     assert isinstance(colfilters, dict)
     for k, v in colfilters.items():
         assert isinstance(k, str)
         assert isinstance(v, str)
+    """
+
+    # 4.5
+    """ structure:
+    [
+        {
+            "columnFilter": {
+                "aqlExpression": '("specific_data.data.name" == ' 'regexMatch("a", "i"))',
+                "arrayFields": [],
+                "complexNestedFields": [],
+                "complexParentToUnwind": None,
+                "fieldPath": "specific_data.data.name",
+                "fieldType": "string",
+                "filterExpressions": [
+                    {
+                        "bracketWeight": 0,
+                        "children": [],
+                        "compOp": "columnFilterContains",
+                        "field": "specific_data.data.name",
+                        "fieldType": "axonius",
+                        "filter": '("specific_data.data.name" ' '== regexMatch("a", "i"))',
+                        "leftBracket": 0,
+                        "logicOp": "",
+                        "not": False,
+                        "rightBracket": 0,
+                        "value": "a",
+                    }
+                ],
+                "isComplexField": False,
+                "isComplexNestedField": False,
+                "nestedFilteredFields": [],
+            },
+            "fieldPath": "specific_data.data.name",
+        }
+    ]
+    """
+    colfilters = view.pop("colFilters", [])
+    assert isinstance(colfilters, list)
+    for colfilter in colfilters:
+        assert isinstance(colfilter, dict)
 
     qfilter = query.pop("filter")
     assert isinstance(qfilter, str) or qfilter is None
@@ -399,9 +447,19 @@ def validate_sq(asset):
     historical = view.pop("historical", None)
     assert historical is None or isinstance(historical, SIMPLE)
 
+    """ changed in 4.5
     # 3.6+
     excluded_adapters = view.pop("colExcludedAdapters", {})
     assert isinstance(excluded_adapters, dict)
+    """
+    # 4.5
+    """ structure
+    [{"exclude": ["chef_adapter"], "fieldPath": "specific_data.data.name"}]
+    """
+    excluded_adapters = view.pop("colExcludedAdapters", [])
+    assert isinstance(excluded_adapters, list)
+    for excluded_adapter in excluded_adapters:
+        assert isinstance(excluded_adapter, dict)
 
     # 4.0
     always_cached = asset.pop("always_cached")

--- a/axonius_api_client/tests/tests_api/tests_system/test_instances.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_instances.py
@@ -34,6 +34,10 @@ class TestInstancesPublic:
             v = data.pop(i)
             assert isinstance(v, bool)
 
+        # new in 4.5
+        now_offset = data.pop("now_offset")
+        assert isinstance(now_offset, int)
+
         assert not data
 
     def test_get_set_core_delete_mode(self, apiobj):
@@ -178,26 +182,24 @@ class TestInstancesPrivate:
         assert reget is use_env
 
     def test_get_update_central_core(self, apiobj):
-        settings = apiobj._get_central_core_config()
-        assert isinstance(settings, json_api.system_settings.SystemSettings)
+        original = apiobj._get_central_core_config()
+        assert isinstance(original, json_api.system_settings.SystemSettings)
 
-        config_key = "delete_backups"
-        value_orig = settings.config[config_key]
-        value_to_set = not value_orig
+        value_original = original.config["delete_backups"]
+        value_to_set = not value_original
 
-        to_update = {}
-        to_update.update(settings.config)
-        to_update[config_key] = value_to_set
-        updated = apiobj._update_central_core_config(**to_update)
+        updated = apiobj._update_central_core_config(
+            delete_backups=value_to_set, enabled=original.config["enabled"]
+        )
         assert isinstance(updated, json_api.system_settings.SystemSettings)
-        assert updated.config == to_update
+        assert updated.config["delete_backups"] == value_to_set
+        assert updated.config["enabled"] == original.config["enabled"]
 
-        to_restore = {}
-        to_restore.update(settings.config)
-        to_restore[config_key] = value_orig
-
-        restored = apiobj._update_central_core_config(**to_restore)
-        assert restored.config == settings.config
+        restored = apiobj._update_central_core_config(
+            delete_backups=value_original, enabled=original.config["enabled"]
+        )
+        assert restored.config["delete_backups"] == value_original
+        assert restored.config["enabled"] == original.config["enabled"]
 
     def test_feature_flags(self, apiobj):
         value = apiobj._feature_flags()

--- a/axonius_api_client/tests/tests_api/tests_system/test_system_roles.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_system_roles.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Test suite."""
 import pytest
-
-from axonius_api_client.api.json_api.system_roles import SystemRole
+from axonius_api_client.api import json_api
 from axonius_api_client.exceptions import ApiError, NotFoundError
 
 NAME = "badwolf"
@@ -26,20 +25,79 @@ class TestSystemRolesPrivate:
         roles = apiobj._get()
         assert isinstance(roles, list) and roles
         for role in roles:
-            assert isinstance(role, SystemRole)
+            assert isinstance(role, (json_api.system_roles.SystemRole,))
 
     def test_add_update_delete(self, apiobj):
         cleanup(apiobj)
-        role = apiobj._add(name=NAME, permissions={})
-        assert isinstance(role, SystemRole)
+        role = apiobj._add(
+            name=NAME,
+            permissions={
+                "adapters": {
+                    "connections": {"delete": True, "post": True, "put": True, "terminate": True},
+                    "get": True,
+                    "put": True,
+                },
+                "api_access": {"api_access_enabled": True, "reset_api_key": True},
+                "compliance": {"exclusions_and_comments": {"put": True}, "get": True, "put": True},
+                "dashboard": {
+                    "charts": {"delete": True, "post": True, "put": True},
+                    "get": True,
+                    "spaces": {"delete": True, "post": True, "refresh": True},
+                },
+                "devices_assets": {
+                    "get": True,
+                    "put": True,
+                    "saved_queries": {"delete": True, "post": True, "put": True, "run": True},
+                },
+                "enforcements": {
+                    "delete": True,
+                    "duplicate": True,
+                    "get": True,
+                    "post": True,
+                    "put": True,
+                    "run": True,
+                    "tasks": {"get": True, "terminate": True},
+                },
+                "general_actions": {"export_csv": True},
+                "instances": {"get": True, "put": True, "run": True},
+                "queries_history": {"get": True},
+                "reports": {
+                    "deactivate": True,
+                    "delete": True,
+                    "get": True,
+                    "post": True,
+                    "private": True,
+                    "put": True,
+                },
+                "settings": {
+                    "audit": {"get": True},
+                    "data_scope": True,
+                    "get": True,
+                    "get_users_and_roles": True,
+                    "manage_admin_users": True,
+                    "manage_service_accounts": True,
+                    "notifications": {"get": True},
+                    "put": True,
+                    "roles": {"delete": True, "post": True, "put": True},
+                    "run_manual_discovery": True,
+                    "users": {"delete": True, "post": True, "put": True},
+                },
+                "users_assets": {
+                    "get": True,
+                    "put": True,
+                    "saved_queries": {"delete": True, "post": True, "put": True, "run": True},
+                },
+            },
+        )
+        assert isinstance(role, (json_api.system_roles.SystemRole,))
 
         assert role.name == NAME
         updated = apiobj._update(name=NEW_NAME, uuid=role.uuid, permissions=role.permissions)
-        assert isinstance(updated, SystemRole)
+        assert isinstance(updated, (json_api.system_roles.SystemRole,))
         assert updated.name == NEW_NAME
 
         deleted = apiobj._delete(uuid=role.uuid)
-        assert isinstance(role, SystemRole)
+        assert isinstance(role, (json_api.system_roles.SystemRole,))
         assert deleted.document_meta == {"name": NEW_NAME}
         cleanup(apiobj)
 

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.10.6"
+__version__ = "4.10.7"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.10.7](#4107)
    - [AXONSHELL](#axonshell)
        - [FIXES](#fixes)
        - [NEW COMMANDS](#new-commands)
        - [NEW ARGUMENTS](#new-arguments)
        - [ENHANCEMENTS](#enhancements)
    - [API Library](#api-library)
        - [FIXES](#fixes-1)
            - [devices/users.get](#devicesusersget)
        - [NEW METHODS](#new-methods)
        - [NEW ARGUMENTS](#new-arguments-1)
        - [ENHANCEMENTS](#enhancements-1)

<!-- /MarkdownTOC -->

# 4.10.7

## AXONSHELL

### FIXES

n/a

### NEW COMMANDS

n/a

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

n/a 

## API Library

### FIXES

#### devices/users.get

- Performance improved when using 'field_explode': no longer using copy.deepcopy()

### NEW METHODS

n/a 

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

- Add debug timing for asset callbacks
- Improved handling for non-strict schemas
- Add support for new field format 'string-date'
