### PR TITLE
4.10.8

### DIFF
--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -145,6 +145,7 @@ class Parsers(BaseEnum):
     to_str_escaped_regex = enum.auto()
     to_str_subnet = enum.auto()
     to_str_tags = enum.auto()
+    to_str_sq_name = enum.auto()
 
 
 class Types(BaseEnum):
@@ -174,6 +175,7 @@ class Formats(BaseEnum):
     os_distribution = "os-distribution"
     dynamic_field = enum.auto()
     date = enum.auto()  # added 4.5
+    sq_name = enum.auto()
 
 
 @dataclasses.dataclass
@@ -276,6 +278,11 @@ class Operators(BaseData):
         name_map=OperatorNameMaps.equals,
         template='({field} == "{aql_value}")',
         parser=Parsers.to_str_cnx_label,
+    )
+    equals_str_sq_name: Operator = Operator(
+        name_map=OperatorNameMaps.equals,
+        template="({{{{QueryID={aql_value}}}}})",
+        parser=Parsers.to_str_sq_name,
     )
     equals_ip: Operator = Operator(
         name_map=OperatorNameMaps.equals,
@@ -453,6 +460,14 @@ class OperatorTypeMap(BaseData):
 class OperatorTypeMaps(BaseData):
     """Operator type map that maps operators to a specific field schemas."""
 
+    string_sq_name: OperatorTypeMap = OperatorTypeMap(
+        name="string_sq_name",
+        operators=[
+            Operators.equals_str_sq_name,
+        ],
+        field_type=Types.string,
+        field_format=Formats.sq_name,
+    )
     string_cnx_label: OperatorTypeMap = OperatorTypeMap(
         name="string_cnx_label",
         operators=[
@@ -807,7 +822,32 @@ CUSTOM_FIELDS_MAP: Dict[str, List[dict]] = {
             "format": "connection_label",
             "type_norm": "string_cnx_label",
             "is_agg": True,
-            "selectable": False,
+            "selectable": True,
+            "expr_field_type": AGG_EXPR_FIELD_TYPE,
+            "is_details": False,
+            "is_all": False,
+        },
+        {
+            "adapter_name_raw": f"{AGG_ADAPTER_NAME}_adapter",
+            "adapter_name": AGG_ADAPTER_NAME,
+            "adapter_title": AGG_ADAPTER_TITLE,
+            "adapter_prefix": "specific_data",
+            "column_name": f"{AGG_ADAPTER_NAME}:sq",
+            "column_title": f"{AGG_ADAPTER_TITLE}: Saved Query Name",
+            "sub_fields": [],
+            "is_complex": False,
+            "is_list": False,
+            "is_root": True,
+            "parent": "root",
+            "name": "specific_data.sq",
+            "name_base": "sq",
+            "name_qual": "specific_data.sq",
+            "title": "Saved Query Name",
+            "type": "string",
+            "format": "sq_name",
+            "type_norm": "string_sq_name",
+            "is_agg": True,
+            "selectable": True,
             "expr_field_type": AGG_EXPR_FIELD_TYPE,
             "is_details": False,
             "is_all": False,

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -6,7 +6,7 @@ import warnings
 from typing import Dict, List, Optional
 
 from ..data import BaseData, BaseEnum
-from ..exceptions import NotFoundError
+from ..exceptions import NotFoundError, UnknownFieldSchema
 
 AGG_ADAPTER_NAME: str = "agg"
 """Short name to use for aggregated adapter"""
@@ -771,9 +771,8 @@ class OperatorTypeMaps(BaseData):
                 return typemap.default
 
         assume = "array of string" if is_array else "string"
-        warnings.warn(
-            f"Unexepected schema in field {name!r} with {attrs_text}, falling back to {assume}"
-        )
+        msg = f"Unexepected schema in field {name!r} with {attrs_text}, falling back to {assume}"
+        warnings.warn(message=msg, category=UnknownFieldSchema)
         return OperatorTypeMaps.array_string if is_array else OperatorTypeMaps.string
 
     @classmethod

--- a/axonius_api_client/exceptions.py
+++ b/axonius_api_client/exceptions.py
@@ -13,6 +13,10 @@ class ApiWarning(AxonWarning):
     """Warnings for API models."""
 
 
+class UnknownFieldSchema(ApiWarning):
+    """Warning for unknown field schema mappings."""
+
+
 class JsonApiIncorrectType(ApiWarning):
     """Pass."""
 

--- a/axonius_api_client/tests/meta.py
+++ b/axonius_api_client/tests/meta.py
@@ -87,6 +87,7 @@ FIELD_FORMATS = [
     "version",
     "dynamic_field",  # ~3.13
     "date",  # 4.5
+    "sq_name",
 ]
 SCHEMA_FIELD_FORMATS = FIELD_FORMATS
 SCHEMA_TYPES = ["string", "bool", "array", "integer", "number", "file"]

--- a/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
+++ b/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
@@ -281,19 +281,19 @@ class TestCnxPublic(TestCnxBase):
         cnx_added = apiobj.cnx.add(adapter_name=CSV_ADAPTER, **config)
         for k, v in config.items():
             assert v == cnx_added["config"][k]
+        client_id = cnx_added["id"]
 
         del_result = apiobj.cnx.delete_by_id(
-            cnx_id=cnx_added["id"],
+            cnx_id=client_id,
             adapter_name=CSV_ADAPTER,
             delete_entities=True,
         )
-
         assert isinstance(del_result, json_api.adapters.CnxDelete)
-        assert del_result.client_id == "{'client_id': 'badwolf'}"
+        assert del_result.client_id == f"{{'client_id': '{client_id}'}}"
 
         with pytest.raises(NotFoundError):
             apiobj.cnx.get_by_id(
-                cnx_id=cnx_added["id"],
+                cnx_id=client_id,
                 adapter_name=CSV_ADAPTER,
             )
 
@@ -305,21 +305,22 @@ class TestCnxPublic(TestCnxBase):
             "file_path": file_path,
         }
         cnx_added = apiobj.cnx.add(adapter_name=CSV_ADAPTER, **config)
+        client_id = cnx_added["id"]
 
         assert isinstance(cnx_added["config"]["file_path"], dict)
 
         del_result = apiobj.cnx.delete_by_id(
-            cnx_id=cnx_added["id"],
+            cnx_id=client_id,
             adapter_name=CSV_ADAPTER,
             delete_entities=True,
         )
 
         assert isinstance(del_result, json_api.adapters.CnxDelete)
-        assert del_result.client_id == "{'client_id': 'badwolf'}"
+        assert del_result.client_id == f"{{'client_id': '{client_id}'}}"
 
         with pytest.raises(NotFoundError):
             apiobj.cnx.get_by_id(
-                cnx_id=cnx_added["id"],
+                cnx_id=client_id,
                 adapter_name=CSV_ADAPTER,
             )
 
@@ -348,19 +349,19 @@ class TestCnxPublic(TestCnxBase):
         assert not hasattr(exc.value, "cnx_old")
         assert getattr(exc.value, "result", None)
         cnx_added = exc.value.cnx_new
-
+        client_id = cnx_added["id"]
         del_result = apiobj.cnx.delete_by_id(
-            cnx_id=cnx_added["id"],
+            cnx_id=client_id,
             adapter_name=CSV_ADAPTER,
             delete_entities=True,
         )
 
         assert isinstance(del_result, json_api.adapters.CnxDelete)
-        assert del_result.client_id == "{'client_id': 'badwolf'}"
+        assert del_result.client_id == f"{{'client_id': '{client_id}'}}"
 
         with pytest.raises(NotFoundError):
             apiobj.cnx.get_by_id(
-                cnx_id=cnx_added["id"],
+                cnx_id=client_id,
                 adapter_name=CSV_ADAPTER,
                 retry=2,
             )

--- a/axonius_api_client/tests/tests_api/tests_parsers/test_constants.py
+++ b/axonius_api_client/tests/tests_api/tests_parsers/test_constants.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Test suite."""
 import pytest
-
 from axonius_api_client.constants.fields import Operators, OperatorTypeMaps
-from axonius_api_client.exceptions import NotFoundError
+from axonius_api_client.exceptions import NotFoundError, UnknownFieldSchema
 
 
 class TestOperatorTypeMaps:
@@ -14,7 +13,7 @@ class TestOperatorTypeMaps:
 
     def test_get_type_map_invalid(self):
         field = {"type": "badwolf", "name_qual": "badwolf"}
-        with pytest.raises(NotFoundError):
+        with pytest.warns(UnknownFieldSchema):
             OperatorTypeMaps.get_type_map(field=field)
 
     def test_get_operator(self):

--- a/axonius_api_client/tests/tests_api/tests_system/test_meta.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_meta.py
@@ -38,6 +38,10 @@ class SystemMetaBase:
 
         devices = entity_sizes.pop("Devices", {})
         assert isinstance(devices, dict) or users is None
+
+        resources = entity_sizes.pop("Resources", None)  # 4.5
+        assert isinstance(resources, dict) or resources is None
+
         assert not entity_sizes
         assert not data
 

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.10.7"
+__version__ = "4.10.8"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.10.7](#4107)
    - [AXONSHELL](#axonshell)
        - [FIXES](#fixes)
        - [NEW COMMANDS](#new-commands)
        - [NEW ARGUMENTS](#new-arguments)
        - [ENHANCEMENTS](#enhancements)
    - [API Library](#api-library)
        - [FIXES](#fixes-1)
            - [devices/users.get](#devicesusersget)
        - [NEW METHODS](#new-methods)
        - [NEW ARGUMENTS](#new-arguments-1)
        - [ENHANCEMENTS](#enhancements-1)

<!-- /MarkdownTOC -->

# 4.10.7

## AXONSHELL

### FIXES

n/a

### NEW COMMANDS

n/a

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

n/a 

## API Library

### FIXES

#### API Query Wizard

- Added saved query support via:
```simple sq equals $NAME_OF_SQ```

### NEW METHODS

n/a 

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

- Unknown/unexpected field schemas will no longer error out
  - they will now throw a warning and fallback to a string type
