### PR TITLE
4.10.9

### DIFF
--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """API for working with saved queries for assets."""
+import warnings
+
 from typing import Generator, List, Optional, Union
 
 from ...constants.api import MAX_PAGE_SIZE
-from ...exceptions import NotFoundError, ResponseError
+from ...exceptions import NotFoundError, ResponseError, ApiWarning
 # from ...features import Features
 from ...parsers.tables import tablize_sqs
 from ...tools import check_gui_page_size, listify
@@ -283,9 +285,12 @@ class SavedQuery(ChildMixins):
         data_view["fields"] = fields
         data_view["pageSize"] = gui_page_size
         # 4.5 SEMI_BREAKING_CHANGE: now a list of dict
-        data_view["colFilters"] = listify(data_column_filters or {})
+        # data_view["colFilters"] = listify(data_column_filters or {})
+        if data_column_filters:
+            msg = f"Column filters structure has changed and is currently not supported by the API client."
+            warnings.warn(message=msg, category=ApiWarning)
         # 4.5 SEMI_BREAKING_CHANGE: now a list of dict
-        data_view["colExcludedAdapters"] = listify({})  # TBD
+        # data_view["colExcludedAdapters"] = listify({})  # TBD
 
         # data = {}
         # data["name"] = name

--- a/axonius_api_client/api/wizards/wizard.py
+++ b/axonius_api_client/api/wizards/wizard.py
@@ -272,6 +272,7 @@ class Wizard:
             idx=idx,
             value=expr_value,
             op_comp=operator.name_map.op,
+            field_name_override=operator.field_name_override,
             query=query,
         )
         return expr

--- a/axonius_api_client/cli/grp_assets/grp_saved_query/cmd_delete_by_name.py
+++ b/axonius_api_client/cli/grp_assets/grp_saved_query/cmd_delete_by_name.py
@@ -31,6 +31,6 @@ def cmd(ctx, url, key, secret, **kwargs):
         rows = apiobj.saved_query.get_by_name(**kwargs)
         apiobj.saved_query.delete(rows=rows)
 
-    ctx.obj.echo_ok("Successfully deleted saved query: rows['name']")
+    ctx.obj.echo_ok(f"Successfully deleted saved query: {rows['name']}")
 
     ctx.exit(0)

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -196,6 +196,7 @@ class OperatorNameMaps(BaseData):
     count_more_than: OperatorNameMap = OperatorNameMap(name="count_above", op="count_above")
     endswith: OperatorNameMap = OperatorNameMap(name="endswith", op="ends")
     equals: OperatorNameMap = OperatorNameMap(name="equals", op="equals")
+    equals_empty: OperatorNameMap = OperatorNameMap(name="equals", op="")
     exists: OperatorNameMap = OperatorNameMap(name="exists", op="exists")
     is_false: OperatorNameMap = OperatorNameMap(name="false", op="false")
     is_true: OperatorNameMap = OperatorNameMap(name="true", op="true")
@@ -280,7 +281,7 @@ class Operators(BaseData):
         parser=Parsers.to_str_cnx_label,
     )
     equals_str_sq_name: Operator = Operator(
-        name_map=OperatorNameMaps.equals,
+        name_map=OperatorNameMaps.equals_empty,
         template="({{{{QueryID={aql_value}}}}})",
         parser=Parsers.to_str_sq_name,
     )

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -224,6 +224,7 @@ class Operator(BaseData):
     template: str
     name_map: OperatorNameMap
     parser: Parsers
+    field_name_override: Optional[str] = None
 
 
 def ops_clean(operators: List[Operator], clean: List[Operator]):
@@ -284,6 +285,7 @@ class Operators(BaseData):
         name_map=OperatorNameMaps.equals_empty,
         template="({{{{QueryID={aql_value}}}}})",
         parser=Parsers.to_str_sq_name,
+        field_name_override="saved_query",
     )
     equals_ip: Operator = Operator(
         name_map=OperatorNameMaps.equals,

--- a/axonius_api_client/constants/wizards.py
+++ b/axonius_api_client/constants/wizards.py
@@ -369,6 +369,7 @@ class Expr:
         field: dict,
         idx: int,
         op_comp: str,
+        field_name_override: Optional[str] = None,
         value: Optional[Union[int, str, bool]] = None,
         is_complex: bool = False,
         children: Optional[List[dict]] = None,
@@ -380,6 +381,7 @@ class Expr:
             query: AQL string
             field: schema of field
             idx: index of this expression
+            field_name_override: value to use as name of field in expr instead of 'name' key from field dict
             value: raw expression value
             op_comp: comparison operator
             is_complex: build an expression for a complex filter
@@ -412,11 +414,16 @@ class Expr:
         else:
             op_logic = cls.OP_IDX0
 
+        if isinstance(field_name_override, str):
+            field_name = field_name_override
+        else:
+            field_name = field[Fields.NAME]
+
         expression = {}
         expression[cls.BRACKET_WEIGHT] = weight
         expression[cls.CHILDREN] = children or [cls.build_child()]
         expression[cls.OP_COMP] = op_comp
-        expression[cls.FIELD] = field[Fields.NAME]
+        expression[cls.FIELD] = field_name
         expression[cls.FIELD_TYPE] = field[Fields.EXPR_TYPE]
         expression[cls.FILTER] = query
         expression[cls.FILTER_ADAPTERS] = None

--- a/axonius_api_client/constants/wizards.py
+++ b/axonius_api_client/constants/wizards.py
@@ -432,6 +432,8 @@ class Expr:
         expression[cls.NOT] = is_not
         expression[cls.BRACKET_RIGHT] = is_right
         expression[cls.VALUE] = value
+        if idx:
+            expression[cls.IDX] = idx
 
         if is_complex:
             expression[cls.CONTEXT] = cls.CONTEXT_OBJ

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.10.8"
+__version__ = "4.10.9"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.10.9](#4109)
    - [AXONSHELL](#axonshell)
        - [FIXES](#fixes)
        - [NEW COMMANDS](#new-commands)
        - [NEW ARGUMENTS](#new-arguments)
        - [ENHANCEMENTS](#enhancements)
    - [API Library](#api-library)
        - [FIXES](#fixes-1)
            - [QUERY WIZARD](#query-wizard)
        - [NEW METHODS](#new-methods)
        - [NEW ARGUMENTS](#new-arguments-1)
        - [ENHANCEMENTS](#enhancements-1)

<!-- /MarkdownTOC -->

# 4.10.9

## AXONSHELL

### FIXES

- deleting saved query now prints the name correctly

### NEW COMMANDS

n/a

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

n/a 

## API Library

### FIXES

#### QUERY WIZARD

- compOp must be empty string!
- field must be saved_query not specific_data.sq!
- add index for parent expression entries
- temp. disabled column filters due to object shape change

### NEW METHODS

n/a 

### NEW ARGUMENTS

n/a

### ENHANCEMENTS

n/a

