### PR TITLE
4.20.2 (pre-release)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,4 @@ shell.py
 .idea
 axonius_oas*.yaml
 artifacts/
+/*.pem

--- a/axonius_api_client/cli/grp_certs/cmd_from_path.py
+++ b/axonius_api_client/cli/grp_certs/cmd_from_path.py
@@ -26,6 +26,6 @@ OPTIONS = [
 def cmd(ctx, input_file, **kwargs):
     """Display/convert certificates from a PEM, DER, or PKCS7 file."""
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        chain = from_path(path=input_file)
+        chain = from_path(path=input_file, split=False)
         handle_export(data=chain, **kwargs)
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_certs/grp_common.py
+++ b/axonius_api_client/cli/grp_certs/grp_common.py
@@ -23,7 +23,12 @@ def export_str(data, **kwargs):
     def dump(obj):
         return obj.to_str()
 
-    return "\n\n".join([dump(x) for x in data]) if isinstance(data, list) else dump(data)
+    barrier = "-" * 80
+    return (
+        f"\n\n{barrier}".join([dump(x) for x in data])
+        if isinstance(data, (tuple, list))
+        else dump(data)
+    )
 
 
 def export_pem(data, **kwargs):

--- a/axonius_api_client/tests/tests_api/tests_system/test_settings.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_settings.py
@@ -5,7 +5,6 @@
 # import subprocess
 
 import pytest
-
 from axonius_api_client import cert_human
 from axonius_api_client.api.json_api.generic import ApiBase
 from axonius_api_client.api.json_api.system_settings import CertificateDetails
@@ -238,7 +237,7 @@ class TestSettingsGlobal(SettingsBasePublic):
         chain = apiobj.gui_cert_reset(True)
         self.check_chain(chain)
 
-    @pytest.mark.datafiles("certs/server_rsa.crt.pem", "certs/server_rsa.key.pem")
+    @pytest.mark.datafiles("certs/server_rsa.crt.pem", "certs/server_rsa.key")
     def test_gui_cert_update(self, apiobj, datafiles):
         path_cert, path_key = datafiles
         chain = apiobj.gui_cert_update_path(

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -671,10 +671,10 @@ def path_write(
     obj = get_path(obj=obj)
 
     if is_json:
-        data = json_dump(combo_dicts(kwargs, obj=data))
+        data = json_dump(**combo_dicts(kwargs, obj=data))
 
     if suffix_auto:
-        data = auto_suffix(combo_dicts(kwargs, path=obj, data=data))
+        data = auto_suffix(**combo_dicts(kwargs, path=obj, data=data))
 
     if binary:
         if isinstance(data, str):

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.20.1"
+__version__ = "4.20.2"
 VERSION: str = __version__
 """Version of package."""
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(path: str, clean: bool = True) -> List[str]:
 ABOUT = {}
 CONTENTS = "\n".join(read(path=PATH_VERSION))
 exec(CONTENTS, ABOUT)
-README = read(path=PATH_README, clean=False)
+README = "\n".join(read(path=PATH_README, clean=False))
 INSTALL_REQUIRES = [x.strip() for x in read(path=PATH_REQ)]
 
 setup(


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.20.2](#4202)
  - [AXONSHELL](#axonshell)
    - [AXONSHELL fixes](#axonshell-fixes)
    - [AXONSHELL enhancments](#axonshell-enhancments)
  - [API Library](#api-library)
    - [API Library fixes](#api-library-fixes)

<!-- /MarkdownTOC -->

# 4.20.2

:warning: **This is a pre-release**

While this version is tested thoroughly, there are a number of core changes to support working with SSL certificates that could produce errors in certain edge cases. 

The version that gets installed by pip will be the latest NON pre-release:
```pip install axonius-api-client```

In order to install a version marked as a pre-release, you need to specify the exact version with pip:
```pip install axonius-api-client==4.20.2```

## AXONSHELL

### AXONSHELL fixes

- axonshell certs from-file
```
'tuple' object has no attribute 'to_str'
```

- axonshell certs gui-get
```
** ERROR: WRAPPED EXCEPTION: builtins.FileNotFoundError
[Errno 2] No such file or directory: '/Users/jimbo/gh/Axonius/axonapi/10.20.3.233.pem'
  ```

### AXONSHELL enhancments

- axonshell certs *
  - add a barrier between each certificate printed out in str format

## API Library

### API Library fixes

- axonius_api_client.http.Http - fix requests environment variable merging
  - If OS Environment variable `REQUESTS_CA_BUNDLE` exists, it would replace the supplied certpath causing SSL verification to fail.
  - Fixed by passing in values from session instead of None.

