### PR TITLE
windows does not support : in filename

### DIFF
--- a/axonius_api_client/constants/general.py
+++ b/axonius_api_client/constants/general.py
@@ -62,4 +62,4 @@ IS_MAC: bool = sys.platform == "darwin"
 """Running on a mac platform"""
 
 TRIM_MSG: str = "\nTrimmed {value_len} {trim_type} down to {trim}"
-FILE_DATE_FMT: str = "%Y-%m-%dT%H:%M:%S"
+FILE_DATE_FMT: str = "%Y-%m-%dT%H-%M-%S"

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.20.3"
+__version__ = "4.20.4"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.20.4](#4204)
    - [AXONSHELL](#axonshell)
        - [AXONSHELL bugfixes](#axonshell-bugfixes)

<!-- /MarkdownTOC -->

# 4.20.4

:warning: **This is a pre-release**

While this version is tested thoroughly, there are a number of core changes to support working with SSL certificates that could produce errors in certain edge cases. 

The version that gets installed by pip will be the latest NON pre-release:
```pip install axonius-api-client```

In order to install a version marked as a pre-release, you need to specify the exact version with pip:
```pip install axonius-api-client==4.20.3```

## AXONSHELL

### AXONSHELL bugfixes

- axonshell devices/users get
  - Fixed support for templating in --export-path and --export-file, windows does not support ':' in filename
