### PR TITLE
4.20.4

### DIFF
--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -671,10 +671,10 @@ def path_write(
     obj = get_path(obj=obj)
 
     if is_json:
-        data = json_dump(combo_dicts(kwargs, obj=data))
+        data = json_dump(**combo_dicts(kwargs, obj=data))
 
     if suffix_auto:
-        data = auto_suffix(combo_dicts(kwargs, path=obj, data=data))
+        data = auto_suffix(**combo_dicts(kwargs, path=obj, data=data))
 
     if binary:
         if isinstance(data, str):


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.20.4](#4204)
    - [AXONSHELL](#axonshell)
        - [AXONSHELL bugfixes](#axonshell-bugfixes)

<!-- /MarkdownTOC -->

# 4.20.4

:warning: **This is a pre-release**

While this version is tested thoroughly, there are a number of core changes to support working with SSL certificates that could produce errors in certain edge cases. 

The version that gets installed by pip will be the latest NON pre-release:
```pip install axonius-api-client```

In order to install a version marked as a pre-release, you need to specify the exact version with pip:
```pip install axonius-api-client==4.20.4```

## AXONSHELL

### AXONSHELL bugfixes

- axonshell devices/users get
  - Fixed support for templating in --export-path and --export-file, windows does not support ':' in filename
