### PR TITLE
Bugfix/assets export csv/empty column names

### DIFF
--- a/axonius_api_client/api/asset_callbacks/base.py
+++ b/axonius_api_client/api/asset_callbacks/base.py
@@ -965,7 +965,7 @@ class Base:
 
         include_details = self.STORE.get("include_details", False)
 
-        fields = listify(self.STORE.get("fields", []))
+        fields = listify(self.STORE.get("fields_parsed", []))
         api_fields = [x for x in self.APIOBJ.FIELDS_API if x not in fields]
 
         if include_details:  # pragma: no cover

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.20.4"
+__version__ = "4.20.5"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.20.5](#4205)
    - [AXONSHELL](#axonshell)
        - [AXONSHELL bugfixes](#axonshell-bugfixes)

<!-- /MarkdownTOC -->

# 4.20.5

:warning: **This is a pre-release**

While this version is tested thoroughly, there are a number of core changes to support working with SSL certificates that could produce errors in certain edge cases. 

The version that gets installed by pip will be the latest NON pre-release:
```pip install axonius-api-client```

In order to install a version marked as a pre-release, you need to specify the exact version with pip:
```pip install axonius-api-client==4.20.5```

## AXONSHELL

### AXONSHELL bugfixes

- axonshell devices/users get
  - empty column headers for --export-format csv
