### PR TITLE
4.30.0

### DIFF
--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -258,6 +258,24 @@ class Instances(ApiEndpointGroup):
         response_as_text=True,
     )
 
+    get_api_version: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/api",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.StrValueSchema,
+        response_model_cls=json_api.generic.StrValue,
+    )
+
+    get_api_versions: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/supported_versions",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.StrValueSchema,
+        response_model_cls=json_api.generic.StrValue,
+    )
+
 
 @dataclasses.dataclass(repr=False)
 class CentralCore(ApiEndpointGroup):
@@ -607,49 +625,67 @@ class Enforcements(ApiEndpointGroup):
 
     # PBUG: so many things wrong with this
 
-    get: ApiEndpoint = ApiEndpoint(
+    get_sets: ApiEndpoint = ApiEndpoint(
         method="get",
-        path="api/V4.0/enforcements",
+        path="api/V4.5/enforcements",
         request_schema_cls=json_api.resources.ResourcesGetSchema,
         request_model_cls=json_api.resources.ResourcesGet,
-        response_schema_cls=json_api.enforcements.EnforcementDetailsSchema,
-        response_model_cls=json_api.enforcements.EnforcementDetails,
+        response_schema_cls=json_api.enforcements.SetBasicSchema,
+        response_model_cls=json_api.enforcements.SetBasic,
     )
 
-    get_full: ApiEndpoint = ApiEndpoint(
+    get_set: ApiEndpoint = ApiEndpoint(
         method="get",
-        path="api/V4.0/enforcements/{uuid}",
+        path="api/V4.5/enforcements/{uuid}",
         request_schema_cls=None,
         request_model_cls=None,
-        response_schema_cls=json_api.enforcements.EnforcementSchema,
-        response_model_cls=json_api.enforcements.Enforcement,
+        response_schema_cls=json_api.enforcements.SetFullSchema,
+        response_model_cls=json_api.enforcements.SetFull,
     )
 
-    delete: ApiEndpoint = ApiEndpoint(
+    delete_set: ApiEndpoint = ApiEndpoint(
         method="delete",
-        path="api/V4.0/enforcements",
+        path="api/V4.5/enforcements",
         request_schema_cls=json_api.generic.DictValueSchema,
         request_model_cls=json_api.generic.DictValue,
         response_schema_cls=json_api.generic.DeletedSchema,
         response_model_cls=json_api.generic.Deleted,
     )
 
-    create: ApiEndpoint = ApiEndpoint(
+    create_set: ApiEndpoint = ApiEndpoint(
         method="post",
-        path="api/V4.0/enforcements",
-        request_schema_cls=json_api.enforcements.EnforcementCreateSchema,
-        request_model_cls=json_api.enforcements.EnforcementCreate,
-        response_schema_cls=json_api.enforcements.EnforcementSchema,
-        response_model_cls=json_api.enforcements.Enforcement,
+        path="api/V4.5/enforcements",
+        request_schema_cls=json_api.enforcements.CreateSchema,
+        request_model_cls=json_api.enforcements.Create,
+        response_schema_cls=json_api.enforcements.SetFullSchema,
+        response_model_cls=json_api.enforcements.SetFull,
     )
 
-    get_actions: ApiEndpoint = ApiEndpoint(
+    update_set: ApiEndpoint = ApiEndpoint(
+        method="put",
+        path="api/V4.5/enforcements/{uuid}",
+        request_schema_cls=json_api.enforcements.UpdateRequestSchema,
+        request_model_cls=json_api.enforcements.UpdateRequest,
+        response_schema_cls=json_api.enforcements.UpdateResponseSchema,
+        response_model_cls=json_api.enforcements.UpdateResponse,
+    )
+
+    copy_set: ApiEndpoint = ApiEndpoint(
+        method="POST",
+        path="api/V4.5/enforcements/duplicate/{uuid}",
+        request_schema_cls=json_api.enforcements.DuplicateSchema,
+        request_model_cls=json_api.enforcements.Duplicate,
+        response_schema_cls=json_api.enforcements.SetFullSchema,
+        response_model_cls=json_api.enforcements.SetFull,
+    )
+
+    get_action_types: ApiEndpoint = ApiEndpoint(
         method="get",
-        path="api/V4.0/enforcements/actions",
+        path="api/V4.5/enforcements/actions",
         request_schema_cls=None,
         request_model_cls=None,
-        response_schema_cls=json_api.enforcements.ActionSchema,
-        response_model_cls=json_api.enforcements.Action,
+        response_schema_cls=json_api.enforcements.ActionTypeSchema,
+        response_model_cls=json_api.enforcements.ActionType,
     )
 
 

--- a/axonius_api_client/api/enforcements/enforcements.py
+++ b/axonius_api_client/api/enforcements/enforcements.py
@@ -1,135 +1,741 @@
 # -*- coding: utf-8 -*-
 """API for working with enforcements."""
+import warnings
 from typing import Generator, List, Optional, Union
 
 from ...constants.api import MAX_PAGE_SIZE
-from ...exceptions import NotFoundError
+from ...exceptions import ApiError, ApiWarning, NotFoundError
 from ...parsers.tables import tablize
 from .. import json_api
 from ..api_endpoints import ApiEndpoints
 from ..mixins import ModelMixins
 
+ActionCategory = json_api.enforcements.ActionCategory
+QueryType = json_api.enforcements.QueryType
+SetDefaults = json_api.enforcements.SetDefaults
+Schedule = json_api.enforcements.Schedule
+MODEL_SQ = json_api.saved_queries.SavedQuery
+MODEL_SQ_MULTI = Union[str, dict, MODEL_SQ]
+MODEL_SET_UPDATE = json_api.enforcements.UpdateResponse
+MODEL_SET_BASIC = json_api.enforcements.SetBasic
+MODEL_SET_FULL = json_api.enforcements.SetFull
+MODEL_SET_BOTH = Union[MODEL_SET_BASIC, MODEL_SET_FULL]
+GEN_SET = Generator[MODEL_SET_BOTH, None, None]
+MULTI_SET = Union[str, dict, MODEL_SET_BASIC, MODEL_SET_FULL, MODEL_SET_UPDATE]
 
-class Enforcements(ModelMixins):  # pragma: no cover
+MODEL_ACTION_TYPE = json_api.enforcements.ActionType
+MULTI_ACTION_TYPE = Union[str, dict, MODEL_ACTION_TYPE]
+
+
+class Enforcements(ModelMixins):
     """API working with enforcements.
 
-    Notes:
-        Future versions of API client 4.x branch will be expanded quite a bit to make it user
-        friendly. The current incarnation should be considered **BETA** until such time.
+    Whats the deal with BASIC vs FULL?
+
+    The REST API exposes an endpoint to page through the enforcement sets, but the details
+    about the actions and triggers configured are limited.
+
+    In order to get the full details of the actions and triggers, one call must be made to
+    fetch the FULL details of each enforcement set by UUID.
+
+    To make things more fun, the FULL model is lacking details that are only provided by the BASIC
+    model: triggers_last_triggered, triggers_times_triggered, updated_by, last_triggered,
+    last_updated. Also the "human friendly" description of trigger schedule is only available from
+    BASIC.
+
+    We overcome this by getting the FULL object and attaching the BASIC object as FULL.BASIC,
+    see :method:`attach_full_set`.
+
+    TBD:
+        get_tasks
+        run
     """
 
-    def get(
-        self, generator: bool = False
-    ) -> Union[
-        Generator[json_api.enforcements.EnforcementDetails, None, None], List[dict]
-    ]:  # pragma: no cover
-        """Get Enforcements.
+    def get_set(self, value: MULTI_SET) -> MODEL_SET_FULL:
+        """Get an enforcement set by name or UUID.
 
         Args:
-            generator: return an iterator for objects that will yield rows as they are fetched
+            value (MULTI_SET): enforcement set model or str with name or uuid
 
+        Raises:
+            ApiError: if invalid type supplied for value
+            NotFoundError: if not found
+
+        Returns:
+            MODEL_SET_FULL: enforcement set model
         """
-        gen = self.get_generator()
+        if isinstance(value, str):
+            name = value
+            uuid = value
+        elif isinstance(value, (MODEL_SET_BASIC, MODEL_SET_FULL, MODEL_SET_UPDATE)):
+            name = value.name
+            uuid = value.uuid
+        elif isinstance(value, dict) and value.get("name") and value.get("uuid"):
+            name = value["name"]
+            uuid = value["uuid"]
+        else:
+            raise ApiError(f"Unknown type {type(value)}, must be {MULTI_SET}")
+
+        items = []
+        for item in self.get_sets_generator(full=True):
+            if name == item.name or uuid == item.uuid:
+                return item
+            items.append(item)
+
+        raise NotFoundError(
+            tablize(
+                value=[x.to_tablize() for x in items],
+                err=f"Enforcement Set with name of {name!r} or UUID of {uuid!r} not found",
+            )
+        )
+
+    def get_sets(
+        self, generator: bool = False, full: bool = True
+    ) -> Union[GEN_SET, List[MODEL_SET_BOTH]]:
+        """Get all enforcement sets.
+
+        Args:
+            generator (bool, optional): return an iterator for objects
+            full (bool, optional): get the full model of each enforcement set
+        """
+        gen = self.get_sets_generator(full=full)
         return gen if generator else list(gen)
 
-    def get_generator(
-        self,
-    ) -> Generator[json_api.enforcements.EnforcementDetails, None, None]:  # pragma: no cover
-        """Get Axonius system users using a generator."""
+    def get_sets_generator(self, full: bool = True) -> GEN_SET:
+        """Get all enforcement sets using a generator.
+
+        Args:
+            full (bool, optional): get the full model of each enforcement set
+
+        Yields:
+            GEN_SET: Generator
+        """
         offset = 0
 
         while True:
-            rows = self._get(offset=offset)
+            rows = self._get_sets(offset=offset)
             offset += len(rows)
 
             if not rows:
                 break
 
             for row in rows:
-                yield row
+                yield self.attach_full_set(value=row) if full else row
 
-    def get_by_name(
-        self, value: str
-    ) -> json_api.enforcements.EnforcementDetails:  # pragma: no cover
-        """Get an enforcement by name.
+    def attach_full_set(self, value: MODEL_SET_BASIC) -> MODEL_SET_FULL:
+        """Fetch the full model of an enforcement set and attach the basic model to it.
 
         Args:
-            value: object name
+            value (MODEL_SET_BASIC): Previously fetched basic model
+
+        Returns:
+            MODEL_SET_FULL: Full model with basic model embedded
 
         Raises:
-            :exc:`NotFoundError`: if not found
+            ApiError: if value is incorrect type
         """
-        data = self.get()
-        found = [x for x in data if x.name == value]
-        if found:
-            return found[0]
+        if not isinstance(value, MODEL_SET_BASIC):
+            raise ApiError(f"Incorrect type {type(value)}, must be {MODEL_SET_BASIC}")
 
-        err = f"Enforcement with name of {value!r} not found"
-        raise NotFoundError(tablize(value=[x.to_tablize() for x in data], err=err))
+        data = self._get_set(uuid=value.uuid)
+        data.BASIC = value
+        return data
 
-    def get_by_uuid(
-        self, value: str
-    ) -> json_api.enforcements.EnforcementDetails:  # pragma: no cover
-        """Get an enforcement by uuid.
+    def check_set_exists(self, value: MULTI_SET):
+        """Check if an enforcement set already exists.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+
 
         Raises:
-            :exc:`NotFoundError`: if user not found
+            ApiError: if enforcement set already exists
         """
-        data = self.get()
-        found = [x for x in data if x.uuid == value]
-        if found:
-            return found[0]
+        try:
+            existing = self.get_set(value=value)
+        except NotFoundError:
+            return
 
-        err = f"Enforcement with uuid of {value!r} not found"
-        raise NotFoundError(tablize(value=[x.to_tablize() for x in data], err=err))
+        raise ApiError(f"enforcement set matching {value!r} already exists:\n{existing}")
 
-    """
+    def get_action_type(self, value: MULTI_ACTION_TYPE) -> MODEL_ACTION_TYPE:
+        """Get an action type.
 
-    enforcement.get_by_name/get_by_uuid()
-    e_obj = OBJECT
-    e_obj.action_main_set(name: str, **config)
-    e_obj.action_add(name: str, type: ["post", "success", "failure"], **config)
-    e_obj.action_remove(name: str)
-    e_obj.trigger_set(asset_type=["users", "devices"], sq="NAME OF SQ", added_only=False)
-    e_obj.trigger_configure(enable=True, schedule=[''], only_added=True/False/None,
-        only_remove=True/False/None)
-    ...
-    """
+        Args:
+            value (MULTI_ACTION_TYPE): action type model or str with name
 
-    # def create(self, name: str, action_name: str, action_type: str, action_config: dict):
-    #     """Pass."""
-    #     enforcements = self.get()
-    #     for enforcement in enforcements:
-    #         if enforcement.name == name:
-    #             raise ApiError(f"Enforcement with name {name!r} already exists:\n{enforcement}")
+        Returns:
+            MODEL_ACTION_TYPE: action type model
 
-    #     action_types = self.get_action_types()
-    #     found_action_type = None
-    #     for action_type in action_types:
-    #         if action_type.name == action_type:
-    #             found_action_type = action_type
+        Raises:
+            ApiError: if value is incorrect type
+            NotFoundError: if not found
+        """
+        if isinstance(value, str):
+            name = value
+        elif isinstance(value, dict) and value.get("id"):
+            name = value["id"]
+        elif isinstance(value, MODEL_ACTION_TYPE):
+            name = value.name
+        else:
+            raise ApiError(f"Unknown type {type(value)}, must be str, dict, or {MODEL_ACTION_TYPE}")
 
-    #     if not found_action_type:
-    #         valid = "\n".join([x.name for x in action_types])
-    #         msg = f"No action type {action_type!r} found, valid action types:\n{valid}"
-    #         raise NotFoundError(msg)
+        items = self.get_action_types()
 
-    #     # TODO: parse action config according to found_action.schema
+        for item in items:
+            if item.name == name:
+                return item
 
-    #     main = {
-    #         "name": action_name,
-    #         "action": {"action_name": action_type, "config": action_config},
-    #     }
-    #     return self._create(name=name, main=main)
+        raise NotFoundError(
+            tablize(
+                value=[x.to_tablize() for x in items],
+                err=f"Action Type with name of {name!r} not found",
+            )
+        )
 
-    def get_action_types(self) -> List[json_api.enforcements.Action]:  # pragma: no cover
-        """Pass."""
+    def get_action_types(self) -> List[MODEL_ACTION_TYPE]:
+        """Get all action types.
+
+        Returns:
+            List[MODEL_ACTION_TYPE]: action type models
+        """
         return self._get_action_types()
 
-    def _get_action_types(self) -> List[json_api.enforcements.Action]:  # pragma: no cover
-        """Pass."""
-        api_endpoint = ApiEndpoints.enforcements.get_action_types
-        return api_endpoint.perform_request(http=self.auth.http)
+    def copy(self, value: MULTI_SET, name: str, copy_triggers: bool = True) -> MODEL_SET_FULL:
+        """Copy an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            name (str): name to assign to copy
+            copy_triggers (bool, optional): copy triggers to new set
+
+        Returns:
+            MODEL_SET_FULL: copied enforcement set
+        """
+        existing = self.get_set(value=value)
+        created = self._copy(uuid=existing.uuid, name=name, clone_triggers=copy_triggers)
+        return self.get_set(value=created)
+
+    def update_name(self, value: MULTI_SET, name: str) -> MODEL_SET_FULL:
+        """Update the name of an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            name (str): name to update
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        self.check_set_exists(value=name)
+        existing.name = name
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_action_main(
+        self, value: MULTI_SET, name: str, action_type: str, config: Optional[dict] = None
+    ) -> MODEL_SET_FULL:
+        """Update the main action of an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            name (str): name to assign to action
+            action_type (str): action type
+            config (Optional[dict], optional): action configuration
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        action = self.get_set_action(name=name, action_type=action_type, config=config)
+        existing.main_action = action
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_action_add(
+        self,
+        value: MULTI_SET,
+        category: Union[ActionCategory, str],
+        name: str,
+        action_type: str,
+        config: Optional[dict] = None,
+    ) -> MODEL_SET_FULL:
+        """Add an action to an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            category (Union[ActionCategory, str]): action category to add action to
+            name (str): name of action to add
+            action_type (str): action type
+            config (Optional[dict], optional): action configuration
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        action = self.get_set_action(name=name, action_type=action_type, config=config)
+        existing.add_action(category=category, action=action)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_action_remove(
+        self, value: MULTI_SET, category: Union[ActionCategory, str], name: str
+    ) -> MODEL_SET_FULL:
+        """Remove an action from an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            category (Union[ActionCategory, str]): action category to remove action from
+            name (str): name of action to remove
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.remove_action(category=category, name=name)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_query(
+        self,
+        value: MULTI_SET,
+        query_name: str,
+        query_type: Union[QueryType, str] = SetDefaults.query_type,
+    ) -> MODEL_SET_FULL:
+        """Update the query of an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            query_name (str): name of saved query
+            query_type (Union[QueryType, str], optional): type of saved query
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        sq = self.get_trigger_view(query_name=query_name, query_type=query_type)
+        existing = self.get_set(value=value)
+        existing.query_update(query_uuid=sq.uuid, query_type=query_type)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_query_remove(self, value: MULTI_SET) -> MODEL_SET_FULL:
+        """Remove the query from an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.query_remove()
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_never(self, value: MULTI_SET) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to never run.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_never()
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_discovery(self, value: MULTI_SET) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to run every discovery.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_discovery()
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_hourly(self, value: MULTI_SET, recurrence: int) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to run hourly.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            recurrence (int): run schedule every N hours (N = 1-24)
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_hourly(recurrence=recurrence)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_daily(
+        self,
+        value: MULTI_SET,
+        recurrence: int,
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to run daily.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            recurrence (int): run enforcement every N days (N = 1-~)
+            hour (int, optional): hour of day to run schedule
+            minute (int, optional): minute of hour to run schedule
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_daily(recurrence=recurrence, hour=hour, minute=minute)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_weekly(
+        self,
+        value: MULTI_SET,
+        recurrence: Union[str, List[Union[str, int]]],
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to run weekly.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            recurrence (Union[str, List[Union[str, int]]]): run enforcement on days of week
+            hour (int, optional): hour of day to run schedule
+            minute (int, optional): minute of hour to run schedule
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_weekly(recurrence=recurrence, hour=hour, minute=minute)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_schedule_monthly(
+        self,
+        value: MULTI_SET,
+        recurrence: Union[str, List[Union[int, str]]],
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ) -> MODEL_SET_FULL:
+        """Set the schedule of an enforcement set to run monthly.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            recurrence (Union[str, List[int]]): run enforcement on days of month
+            hour (int, optional): hour of day to run schedule
+            minute (int, optional): minute of hour to run schedule
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.set_schedule_monthly(recurrence=recurrence, hour=hour, minute=minute)
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_only_new_assets(self, value: MULTI_SET, update: bool) -> MODEL_SET_FULL:
+        """Update enforcement set to only run against newly added assets from last automated run.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            update (bool): False=run against all assets each automated run, True=only run against
+                newly added assets from last automated run
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.only_new_assets = update
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_on_count_increased(self, value: MULTI_SET, update: bool) -> MODEL_SET_FULL:
+        """Update enforcement set to only run if asset count increased from last automated run.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            update (bool): False=run regardless if asset count increased, True=only perform
+                automated run if asset count increased
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.on_count_increased = update
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_on_count_decreased(self, value: MULTI_SET, update: bool) -> MODEL_SET_FULL:
+        """Update enforcement set to only run if asset count decreased from last automated run.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            update (bool): False=run regardless if asset count decreased, True=only perform
+                automated run if asset count decreased
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.on_count_decreased = update
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_on_count_above(self, value: MULTI_SET, update: Optional[int]) -> MODEL_SET_FULL:
+        """Update enforcement set to only run automatically if asset count is above N.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            update (Optional[int]): None to always run automatically regardless of asset count,
+                integer to only run automatically if asset count is above N
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.on_count_above = update
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_on_count_below(self, value: MULTI_SET, update: Optional[int]) -> MODEL_SET_FULL:
+        """Update enforcement set to only run automatically if asset count is below N.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+            update (Optional[int]): None to always run automatically regardless of asset count,
+                integer to only run automatically if asset count is below N
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        existing = self.get_set(value=value)
+        existing.on_count_below = update
+        updated = self.update_from_model(value=existing)
+        return self.get_set(value=updated)
+
+    def update_from_model(self, value: MODEL_SET_FULL) -> MODEL_SET_FULL:
+        """Update an enforcement set from the values in a model.
+
+        Args:
+            value (MODEL_SET_FULL): enforcement set model to update
+
+        Returns:
+            MODEL_SET_FULL: updated enforcement set
+        """
+        return self._update(
+            uuid=value.uuid, name=value.name, actions=value.actions, triggers=value.triggers
+        )
+
+    def create(
+        self,
+        name: str,
+        main_action_name: str,
+        main_action_type: str,
+        main_action_config: Optional[dict] = None,
+        query_name: Optional[str] = SetDefaults.query_name,
+        query_type: str = SetDefaults.query_type,
+        schedule_type: Union[Schedule, str] = SetDefaults.schedule_type,
+        schedule_hour: int = SetDefaults.schedule_hour,
+        schedule_minute: int = SetDefaults.schedule_minute,
+        schedule_recurrence: Optional[Union[int, List[str]]] = SetDefaults.schedule_recurrence,
+        only_new_assets: bool = SetDefaults.only_new_assets,
+        on_count_above: Optional[int] = SetDefaults.on_count_above,
+        on_count_below: Optional[int] = SetDefaults.on_count_below,
+        on_count_increased: bool = SetDefaults.on_count_increased,
+        on_count_decreased: bool = SetDefaults.on_count_decreased,
+    ) -> MODEL_SET_FULL:
+        """Create an enforcement set.
+
+        Args:
+            name (str): Name to assign to enforcement set
+            main_action_name (str): name to assign to main action
+            main_action_type (str): action type to use for main action
+            main_action_config (Optional[dict], optional): action config for main action
+            query_name (Optional[str], optional): Saved Query name to use for trigger
+            query_type (str, optional): Saved Query type
+            schedule_type (Union[Schedule, str], optional): Schedule type for automation
+            schedule_hour (int, optional): Hour of day to use for schedule_type
+            schedule_minute (int, optional): Minute of hour to use for schedule_type
+            schedule_recurrence (Optional[Union[int, List[str]]], optional): recurrence value,
+                type changes based on schedule_type
+            only_new_assets (bool, optional): only run set against assets added since last run
+            on_count_above (Optional[int], optional): only run if asset count above N
+            on_count_below (Optional[int], optional): only run if asset count below N
+            on_count_increased (bool, optional): only run if asset count increased since last run
+            on_count_decreased (bool, optional): only run if asset count decreased since last run
+
+        Returns:
+            MODEL_SET_FULL: created enforcement set
+        """
+        self.check_set_exists(value=name)
+        main = self.get_set_action(
+            name=main_action_name, action_type=main_action_type, config=main_action_config
+        )
+
+        triggers = []
+        sq = self.get_trigger_view(query_name=query_name, query_type=query_type)
+        if sq:
+            triggers.append(
+                Schedule.get_trigger(
+                    query_uuid=sq.uuid,
+                    query_type=query_type,
+                    schedule_type=schedule_type,
+                    schedule_hour=schedule_hour,
+                    schedule_minute=schedule_minute,
+                    schedule_recurrence=schedule_recurrence,
+                    only_new_assets=only_new_assets,
+                    on_count_above=on_count_above,
+                    on_count_below=on_count_below,
+                    on_count_increased=on_count_increased,
+                    on_count_decreased=on_count_decreased,
+                )
+            )
+
+        created = self._create(name=name, main=main, triggers=triggers)
+        return self.get_set(value=created)
+
+    def delete(self, value: MULTI_SET) -> MODEL_SET_FULL:
+        """Delete an enforcement set.
+
+        Args:
+            value (MULTI_SET): enforcement set model or str with name or uuid
+
+        Returns:
+            MODEL_SET_FULL: deleted enforcement set
+        """
+        obj = self.get_set(value=value)
+        self._delete(uuid=obj.uuid)
+        return obj
+
+    def get_set_action(
+        self,
+        name: str,
+        action_type: MULTI_ACTION_TYPE,
+        config: Optional[dict] = None,
+    ) -> dict:
+        """Get the action dictionary needed to add an action to an enforcement set.
+
+        Args:
+            name (str): name to assign to action
+            action_type (MULTI_ACTION_TYPE): action type to use
+            config (Optional[dict], optional): action config
+
+        Returns:
+            dict: action dictionary
+        """
+        action_type = self.get_action_type(value=action_type)
+        config = action_type.check_config(config=config)
+
+        msg = (
+            "CAUTION!!\n"
+            "Adding an action with an incorrect configuration can result in"
+            " an invalid Enforcement Set that can not be deleted!\n"
+            "It is advised to create the appropriate action in the GUI to get an example"
+        )
+        warnings.warn(message=msg, category=ApiWarning)
+
+        return MODEL_SET_FULL.get_action_obj(name=name, action_type=action_type, config=config)
+
+    def get_trigger_view(
+        self,
+        query_name: Optional[MODEL_SQ_MULTI] = SetDefaults.query_name,
+        query_type: Union[QueryType, str] = SetDefaults.query_type,
+    ) -> Optional[MODEL_SQ]:
+        """Get the saved query for use in adding a query to an enforcement.
+
+        Args:
+            query_name (Optional[MODEL_SQ_MULTI], optional): Name of Saved Query
+            query_type (Union[QueryType, str], optional): Type of Saved Query
+
+        Returns:
+            Optional[MODEL_SQ]: None if query_name is not supplied, otherwise saved query model
+        """
+        query_type = QueryType.get_value(query_type)
+
+        if query_name is not None:
+            return self._triggers_map[query_type.value].saved_query.get_by_multi(
+                sq=query_name, as_dataclass=True
+            )
+        return None
+
+    def _init(self, **kwargs):
+        """Post init method for subclasses to use for extra setup."""
+        from .. import Devices, Users, Instances
+
+        self.api_devices: Devices = Devices(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+        self.api_users: Users = Users(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+        self.api_instances: Instances = Instances(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+    @property
+    def _triggers_map(self) -> dict:
+        """Map of query types to api objects."""
+        return {QueryType.devices.value: self.api_devices, QueryType.users.value: self.api_users}
+
+    def _delete(self, uuid: str) -> json_api.generic.Deleted:
+        """Delete an enforcement set by UUID.
+
+        Args:
+            uuid (str): UUID of set to delete
+
+        Returns:
+            json_api.generic.Deleted: deleted model
+        """
+        api_endpoint = ApiEndpoints.enforcements.delete_set
+        request_obj = api_endpoint.load_request(value={"ids": [uuid], "include": True})
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
+
+    def _copy(self, uuid: str, name: str, clone_triggers: bool) -> MODEL_SET_FULL:
+        """Copy an enforcement set.
+
+        Args:
+            uuid (str): UUID of set to copy
+            name (str): name to give copy
+            clone_triggers (bool): copy triggers into new set
+
+        Returns:
+            MODEL_SET_FULL: copied set
+        """
+        api_endpoint = ApiEndpoints.enforcements.copy_set
+        request_obj = api_endpoint.load_request(
+            id=uuid, uuid=uuid, name=name, clone_triggers=clone_triggers
+        )
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
+
+    def _update(
+        self, uuid: str, name: str, actions: dict, triggers: Optional[List[dict]] = None
+    ) -> MODEL_SET_FULL:
+        """Update an enforcement set.
+
+        Args:
+            uuid (str): UUID of set to update
+            name (str): name of set
+            actions (dict): actions of set
+            triggers (Optional[List[dict]], optional): triggers of set
+
+        Returns:
+            MODEL_SET_FULL: updated set
+        """
+        api_endpoint = ApiEndpoints.enforcements.update_set
+        request_obj = api_endpoint.load_request(
+            uuid=uuid, id=uuid, name=name, actions=actions, triggers=triggers or []
+        )
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj, uuid=uuid)
 
     def _create(
         self,
@@ -139,16 +745,19 @@ class Enforcements(ModelMixins):  # pragma: no cover
         failure: Optional[List[dict]] = None,
         post: Optional[List[dict]] = None,
         triggers: Optional[List[dict]] = None,
-    ) -> str:  # pragma: no cover
+    ) -> MODEL_SET_FULL:
         """Create an enforcement set.
 
         Args:
-            name: name of enforcement to create
-            main: main action
-            success: success actions
-            failure: failure actions
-            post: post actions
-            triggers: saved query trigger
+            name (str): name of enforcement to create
+            main (dict): main action
+            success (Optional[List[dict]], optional): success actions
+            failure (Optional[List[dict]], optional): failure actions
+            post (Optional[List[dict]], optional): post actions
+            triggers (Optional[List[dict]], optional): saved query trigger
+
+        Returns:
+            MODEL_SET_FULL: created set
         """
         actions = {
             "main": main,
@@ -156,19 +765,53 @@ class Enforcements(ModelMixins):  # pragma: no cover
             "failure": failure or [],
             "post": post or [],
         }
-        api_endpoint = ApiEndpoints.enforcements.create
+        api_endpoint = ApiEndpoints.enforcements.create_set
         request_obj = api_endpoint.load_request(name=name, actions=actions, triggers=triggers or [])
         return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
 
-    def _get(
-        self, limit: int = MAX_PAGE_SIZE, offset: int = 0
-    ) -> List[json_api.enforcements.EnforcementDetails]:
-        """Direct API method to get enforcements.
+    def _get_sets(
+        self,
+        limit: int = MAX_PAGE_SIZE,
+        offset: int = 0,
+        sort: Optional[str] = None,
+        filter: Optional[str] = None,
+        search: str = "",
+    ) -> List[MODEL_SET_BASIC]:
+        """Get enforcement sets in basic model.
 
         Args:
-            limit: limit to N rows per page
-            offset: start at row N
+            limit (int, optional): limit to N rows per page
+            offset (int, optional): start at row N
+            sort (Optional[str], optional): sort based on a model attribute
+            filter (Optional[str], optional): AQL filter
+            search (str, optional): search string
+
+        Returns:
+            List[MODEL_SET_BASIC]: basic models
         """
-        api_endpoint = ApiEndpoints.enforcements.get
-        request_obj = api_endpoint.load_request(page={"limit": limit, "offset": offset})
+        api_endpoint = ApiEndpoints.enforcements.get_sets
+        request_obj = api_endpoint.load_request(
+            page={"limit": limit, "offset": offset}, filter=filter, search=search, sort=sort
+        )
         return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
+
+    def _get_set(self, uuid: str) -> MODEL_SET_FULL:
+        """Get an enforcement set in full model.
+
+        Args:
+            uuid (str): UUID of set to get
+
+        Returns:
+            MODEL_SET_FULL: full model
+        """
+        api_endpoint = ApiEndpoints.enforcements.get_set
+        return api_endpoint.perform_request(http=self.auth.http, uuid=uuid)
+
+    def _get_action_types(self) -> List[MODEL_ACTION_TYPE]:
+        """Get all action types.
+
+        Returns:
+            List[MODEL_ACTION_TYPE]: action type models
+        """
+        api_endpoint = ApiEndpoints.enforcements.get_action_types
+        return api_endpoint.perform_request(http=self.auth.http)

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -311,7 +311,7 @@ class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
                 and value
                 and not all([isinstance(x, (str, int, bool, float, type(None))) for x in value])
             ):
-                ret += [f"{key} #{idx}: {item}" for idx, item in enumerate(value)]
+                ret += [f"{key} #{idx + 1}: {item}" for idx, item in enumerate(value)]
                 continue
             ret.append(f"{key}: {value}")
         return ret

--- a/axonius_api_client/api/json_api/enforcements.py
+++ b/axonius_api_client/api/json_api/enforcements.py
@@ -2,31 +2,267 @@
 """Models for API requests & responses."""
 import dataclasses
 import datetime
-from typing import List, Optional, Type, Union
+from typing import Any, ClassVar, List, Optional, Type, Union
 
 import marshmallow
 import marshmallow_jsonapi
 
-from ...tools import json_load
+from ...data import BaseEnum
+from ...exceptions import (
+    ApiError,
+    ConfigRequired,
+    ConfigUnknown,
+    NotFoundError,
+    NoTriggerDefinedError,
+    ToolsError,
+)
+from ...tools import coerce_bool, coerce_int, coerce_str_to_csv, int_days_map, json_dump, json_load
 from .base import BaseModel, BaseSchema, BaseSchemaJson
 from .custom_fields import SchemaDatetime, get_field_dc_mm
-from .generic import Deleted
 
 
-class EnforcementDetailsSchema(BaseSchemaJson):  # pragma: no cover
+class SetDefaults:
     """Pass."""
 
-    name = marshmallow_jsonapi.fields.Str()
+    query_name: Optional[str] = None
+    query_type: Union["QueryType", str] = "devices"
+    schedule_type: Union["Schedule", str] = "never"
+    schedule_hour: int = 13
+    schedule_minute: int = 0
+    schedule_recurrence: Optional[Union[int, List[str]]] = None
+    only_new_assets: bool = False
+    on_count_above: Optional[int] = None
+    on_count_below: Optional[int] = None
+    on_count_increased: bool = False
+    on_count_decreased: bool = False
+
+
+class ActionCategory(BaseEnum):
+    """Pass."""
+
+    success: str = "success"
+    failure: str = "failure"
+    post: str = "post"
+
+
+class QueryType(BaseEnum):
+    """Pass."""
+
+    devices: str = "devices"
+    users: str = "users"
+
+
+class OnlyNewAssets(BaseEnum):
+    """Pass."""
+
+    all_entities: str = "AllEntities"
+    added_entities: str = "AddedEntities"
+
+    @classmethod
+    def get_str(cls, value: bool = False) -> str:
+        """Pass."""
+        value = coerce_bool(obj=value, errmsg="only_new_assets must be a boolean")
+        return str(cls.added_entities if value else cls.all_entities)
+
+    @classmethod
+    def get_bool(
+        cls, value: Optional[Union["OnlyNewAssets", str]] = all_entities
+    ) -> Optional[bool]:
+        """Pass."""
+        if value is not None:
+            value = cls.get_value(value=value)
+
+            if value == cls.added_entities:
+                return True
+
+            if value == cls.all_entities:
+                return False
+
+        return None
+
+
+class Schedule(BaseEnum):
+    """Pass."""
+
+    never: str = "never"
+    discovery: str = "all"
+    hourly: str = "hourly"
+    monthly: str = "monthly"
+    daily: str = "daily"
+    weekly: str = "weekly"
+
+    @classmethod
+    def get_value(cls, value: Union["Schedule", str] = SetDefaults.schedule_type) -> "Schedule":
+        """Pass."""
+        return super().get_value(value=value)
+
+    def get_recurrence(self, value: Any = SetDefaults.schedule_recurrence) -> Any:
+        """Pass."""
+        return getattr(self, f"calc_{self.name}")(value=value)
+
+    @staticmethod
+    def get_time(
+        hour: int = SetDefaults.schedule_hour, minute: int = SetDefaults.schedule_minute
+    ) -> str:
+        """Pass."""
+        hour = coerce_int(
+            obj=hour,
+            min_value=0,
+            max_value=23,
+            errmsg="Schedule time hour value must be an integer between 0 and 23",
+        )
+        minute = coerce_int(
+            obj=minute,
+            min_value=0,
+            max_value=59,
+            errmsg="Schedule time minute value must be an integer between 0 and 59",
+        )
+        return f"{hour:0>2}:{minute:0>2}"
+
+    @staticmethod
+    def get_conditions(
+        on_count_above: Optional[int] = SetDefaults.on_count_above,
+        on_count_below: Optional[int] = SetDefaults.on_count_below,
+        on_count_increased: bool = SetDefaults.on_count_increased,
+        on_count_decreased: bool = SetDefaults.on_count_decreased,
+    ) -> dict:
+        """Pass."""
+        return {
+            "new_entities": coerce_bool(
+                obj=on_count_increased, errmsg="on_count_above must be a boolean"
+            ),
+            "previous_entities": coerce_bool(
+                obj=on_count_decreased, errmsg="on_count_below must be a boolean"
+            ),
+            "above": coerce_int(
+                obj=on_count_above,
+                allow_none=True,
+                min_value=0,
+                errmsg="on_count_increased must be None or an integer above 0",
+            ),
+            "below": coerce_int(
+                obj=on_count_below,
+                allow_none=True,
+                min_value=0,
+                errmsg="on_count_decreased must be None or an integer above 0",
+            ),
+        }
+
+    @staticmethod
+    def get_view(
+        query_uuid: Optional[str] = None, query_type: Union[QueryType, str] = SetDefaults.query_type
+    ) -> Optional[dict]:
+        """Pass."""
+        query_type = QueryType.get_value(query_type)
+        if isinstance(query_uuid, str) and query_uuid:
+            return {"id": query_uuid, "entity": query_type.value}
+        return None
+
+    @classmethod
+    def get_trigger(
+        cls,
+        query_uuid: Optional[str] = None,
+        query_type: Union[QueryType, str] = SetDefaults.query_type,
+        schedule_type: Union["Schedule", str] = SetDefaults.schedule_type,
+        schedule_hour: int = SetDefaults.schedule_hour,
+        schedule_minute: int = SetDefaults.schedule_minute,
+        schedule_recurrence: Optional[Union[int, List[str]]] = SetDefaults.schedule_recurrence,
+        only_new_assets: bool = SetDefaults.only_new_assets,
+        on_count_above: Optional[int] = SetDefaults.on_count_above,
+        on_count_below: Optional[int] = SetDefaults.on_count_below,
+        on_count_increased: bool = SetDefaults.on_count_increased,
+        on_count_decreased: bool = SetDefaults.on_count_decreased,
+    ) -> dict:
+        """Pass."""
+        schedule_type = cls.get_value(value=schedule_type)
+        schedule_recurrence = schedule_type.get_recurrence(value=schedule_recurrence)
+        schedule_time = cls.get_time(hour=schedule_hour, minute=schedule_minute)
+        conditions = cls.get_conditions(
+            on_count_above=on_count_above,
+            on_count_below=on_count_below,
+            on_count_increased=on_count_increased,
+            on_count_decreased=on_count_decreased,
+        )
+        run_on = OnlyNewAssets.get_str(value=only_new_assets)
+        view = cls.get_view(query_uuid=query_uuid, query_type=query_type)
+
+        ret = {}
+        ret["name"] = "Trigger"
+        ret["view"] = view
+        ret["period"] = schedule_type.value
+        ret["period_time"] = schedule_time
+
+        if schedule_recurrence is not None:
+            ret["period_recurrence"] = schedule_recurrence
+
+        ret["conditions"] = conditions
+        ret["run_on"] = run_on
+        return ret
+
+    @staticmethod
+    def calc_hourly(value: Any = None) -> int:
+        """Pass."""
+        pre = "Schedule Recurrence of 'hourly'"
+        err_value = f"{pre} must be an integer between 1 and 24"
+        return coerce_int(obj=value, max_value=24, min_value=1, errmsg=err_value)
+
+    @staticmethod
+    def calc_monthly(value: Any = None) -> List[str]:
+        """Pass."""
+        pre = "Schedule Recurrence of 'monthly'"
+        err_values = f"{pre} must be a list or CSV of integers between 1 and 29"
+        err_value = f"{pre} must be an integer between 1 and 29"
+
+        values = coerce_str_to_csv(value=value, coerce_list=True, errmsg=err_values)
+        value = [coerce_int(obj=x, min_value=1, max_value=29, errmsg=err_value) for x in values]
+        return [str(x) for x in sorted(list(set(value)))]
+
+    @staticmethod
+    def calc_weekly(value: Any = None) -> List[str]:
+        """Pass."""
+        pre = "Schedule Recurrence of 'weekly'"
+        err_value = f"{pre} must be a list or CSV of integers between 0 and 6 or day names"
+        try:
+            return int_days_map(value=value, names=False)
+        except Exception as exc:
+            raise ToolsError(f"{err_value}: {exc}")
+
+    @staticmethod
+    def calc_daily(value: Any = None) -> int:
+        """Pass."""
+        pre = "Schedule Recurrence of 'daily'"
+        err_value = f"{pre} must be an integer higher than 1"
+        return coerce_int(obj=value, min_value=1, errmsg=err_value)
+
+    @staticmethod
+    def calc_never(value: Any = None) -> None:
+        """Pass."""
+        return None
+
+    @staticmethod
+    def calc_discovery(value: Any = None) -> None:
+        """Pass."""
+        return None
+
+
+class SetBasicSchema(BaseSchemaJson):
+    """Pass."""
+
     uuid = marshmallow_jsonapi.fields.Str()
-    date_fetched = marshmallow_jsonapi.fields.Str()
-    last_updated = SchemaDatetime(allow_none=True)
-    updated_by = marshmallow_jsonapi.fields.Str(allow_none=True)
+    name = marshmallow_jsonapi.fields.Str()
+
     actions_main = marshmallow_jsonapi.fields.Str()
+    actions_main_name = marshmallow_jsonapi.fields.Str()
     actions_main_type = marshmallow_jsonapi.fields.Str()
+
     triggers_view_name = marshmallow_jsonapi.fields.Str(allow_none=True)
     triggers_last_triggered = marshmallow_jsonapi.fields.Str(allow_none=True)
     triggers_times_triggered = marshmallow_jsonapi.fields.Int(allow_none=True)
     triggers_period = marshmallow_jsonapi.fields.Str(allow_none=True)
+
+    updated_by = marshmallow_jsonapi.fields.Str(allow_none=True)
+    last_triggered = SchemaDatetime(allow_none=True)
+    last_updated = SchemaDatetime(allow_none=True)
 
     class Meta:
         """Pass."""
@@ -34,86 +270,162 @@ class EnforcementDetailsSchema(BaseSchemaJson):  # pragma: no cover
         type_ = "enforcements_details_schema"
 
     @staticmethod
-    def get_model_cls() -> type:  # pragma: no cover
+    def get_model_cls() -> type:
         """Pass."""
-        return EnforcementDetails
+        return SetBasic
 
     @marshmallow.pre_load
-    def pre_load_fix(self, data, **kwargs) -> Union[dict, BaseModel]:  # pragma: no cover
+    def pre_load_fix(self, data, **kwargs):
         """Pass."""
-        data = {k.replace(".", "_"): v for k, v in data.items()}
-        return data
+        return {k.replace(".", "_"): v for k, v in data.items()}
 
 
 @dataclasses.dataclass
-class EnforcementDetails(BaseModel):  # pragma: no cover
+class SetBasic(BaseModel):
     """Pass."""
 
     id: str
+    uuid: str
     name: str
-    date_fetched: str
-    updated_by: str
+
+    actions_main: str
+    actions_main_name: str
     actions_main_type: str
+
     triggers_period: Optional[str] = None
     triggers_view_name: Optional[str] = None
+    triggers_last_triggered: Optional[str] = None
+    triggers_times_triggered: Optional[int] = None
+
+    updated_by: Optional[str] = None
     last_updated: Optional[datetime.datetime] = get_field_dc_mm(
         mm_field=SchemaDatetime(allow_none=True, load_default=None, dump_default=None), default=None
     )
-    actions_main: str = marshmallow_jsonapi.fields.Str()
-    triggers_last_triggered: Optional[str] = None
-    triggers_times_triggered: Optional[int] = None
+    last_triggered: Optional[datetime.datetime] = get_field_dc_mm(
+        mm_field=SchemaDatetime(allow_none=True, load_default=None, dump_default=None), default=None
+    )
+
     document_meta: Optional[dict] = dataclasses.field(default_factory=dict)
 
-    def __post_init__(self):  # pragma: no cover
+    @property
+    def query_name(self) -> Optional[str]:
         """Pass."""
-        self.updated_by = json_load(self.updated_by, error=False)
+        return self.triggers_view_name or None
 
     @property
-    def uuid(self) -> str:  # pragma: no cover
+    def triggered_last_date(self) -> Optional[datetime.datetime]:
         """Pass."""
-        return self.id
+        return self.last_triggered
+
+    @property
+    def triggered_count(self) -> Optional[int]:
+        """Pass."""
+        return self.triggers_times_triggered
+
+    @property
+    def schedule(self) -> Optional[str]:
+        """Pass."""
+        return self.triggers_period or None
+
+    @property
+    def main_action_str(self) -> str:
+        """Pass."""
+        return f"Main Action: {self.actions_main_name!r} ({self.actions_main_type})"
+
+    @property
+    def updated_date(self) -> datetime.datetime:
+        """Pass."""
+        return self.last_updated
+
+    @property
+    def updated_user_obj(self) -> dict:
+        """Pass."""
+        if not hasattr(self, "_updated_user_obj"):
+            self._updated_user_obj = json_load(self.updated_by)
+        return self._updated_user_obj
+
+    @property
+    def updated_user_name(self) -> str:
+        """Get the user name of the user that last updated this set."""
+        return self.updated_user_obj.get("user_name", "")
+
+    @property
+    def updated_user_source(self) -> str:
+        """Get the source of the user that last updated this set."""
+        return self.updated_user_obj.get("source", "")
+
+    @property
+    def updated_user_first_name(self) -> str:
+        """Get the first name of the user that last updated this set."""
+        return self.updated_user_obj.get("first_name", "")
+
+    @property
+    def updated_user_last_name(self) -> str:
+        """Get the last name of the user that last updated this set."""
+        return self.updated_user_obj.get("last_name", "")
+
+    @property
+    def updated_user_full_name(self) -> str:
+        """Get the first and last name of the user that last updated this set."""
+        return " ".join(
+            [x for x in [self.updated_user_first_name, self.updated_user_last_name] if x]
+        )
+
+    @property
+    def updated_user(self) -> str:
+        """Pass."""
+        return f"{self.updated_user_source}/{self.updated_user_name}"
 
     @staticmethod
-    def get_schema_cls() -> Optional[Type[BaseSchema]]:  # pragma: no cover
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
-        return EnforcementDetailsSchema
+        return SetBasicSchema
 
-    @staticmethod
-    def _str_properties() -> List[str]:  # pragma: no cover
+    def __str__(self) -> str:
         """Pass."""
-        return [
-            "name",
-            "uuid",
-            "actions_main",
-            "actions_main_type",
+        items = [
+            f"Name: {self.name!r}",
+            f"UUID: {self.uuid!r}",
+            self.main_action_str,
+            f"Query Name: {self.query_name}",
+            f"Schedule: {self.schedule}",
+            f"Triggered Last Date: {self.triggered_last_date}",
+            f"Triggered Count: {self.triggered_count}",
+            f"Updated Date: {self.updated_date}",
+            f"Updated User: {self.updated_user}",
         ]
+        return "\n".join(items)
 
-    def to_tablize(self):  # pragma: no cover
+    def to_tablize(self):
         """Pass."""
-        return {self._human_key(k): getattr(self, k, None) for k in self._str_properties()}
+        ident = [
+            f"Name: {self.name!r}",
+            f"UUID: {self.uuid!r}",
+            f"Updated Date: {self.updated_date}",
+            f"Updated User: {self.updated_user!r}",
+        ]
+        details = [
+            self.main_action_str,
+            f"Query Name: {self.query_name!r}",
+            f"Schedule: {self.schedule}",
+            f"Triggered Last Date: {self.triggered_last_date}",
+            f"Triggered Count: {self.triggered_count}",
+        ]
+        return {
+            "Identifier": "\n".join(ident),
+            "Details": "\n".join(details),
+        }
 
-    def get_full_object(self) -> "Enforcement":  # pragma: no cover
+    def __repr__(self):
         """Pass."""
-        from .. import ApiEndpoints
-
-        api_endpoint = ApiEndpoints.enforcements.get_full
-        return api_endpoint.perform_request(http=self.HTTP, uuid=self.uuid)
-
-    def delete_object(self) -> Deleted:  # pragma: no cover
-        """Pass."""
-        from .. import ApiEndpoints
-
-        api_endpoint = ApiEndpoints.enforcements.delete
-        request_obj = api_endpoint.load_request(value={"ids": [self.uuid], "include": True})
-        return api_endpoint.perform_request(http=self.HTTP, request_obj=request_obj)
+        return self.__str__()
 
 
-class EnforcementSchema(BaseSchemaJson):  # pragma: no cover
+class SetFullSchema(BaseSchemaJson):
     """Pass."""
 
     name = marshmallow_jsonapi.fields.Str()
     uuid = marshmallow_jsonapi.fields.Str()
-    date_fetched = marshmallow_jsonapi.fields.Str()
     actions = marshmallow_jsonapi.fields.Dict()
     triggers = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Dict())
 
@@ -123,37 +435,617 @@ class EnforcementSchema(BaseSchemaJson):  # pragma: no cover
         type_ = "enforcements_details_schema"
 
     @staticmethod
-    def get_model_cls() -> type:  # pragma: no cover
+    def get_model_cls() -> type:
         """Pass."""
-        return Enforcement
+        return SetFull
 
 
 @dataclasses.dataclass
-class Enforcement(BaseModel):  # pragma: no cover
+class SetFull(BaseModel):
     """Pass."""
 
     id: str
     uuid: str
     name: str
-    date_fetched: str
+    actions: dict
+    triggers: List[dict]
+
+    BASIC: ClassVar[SetBasic] = None
+
+    def set_trigger(
+        self,
+        query_uuid: Optional[str] = None,
+        query_type: str = SetDefaults.query_type,
+        schedule_type: Union["Schedule", str] = SetDefaults.schedule_type,
+        schedule_hour: int = SetDefaults.schedule_hour,
+        schedule_minute: int = SetDefaults.schedule_minute,
+        schedule_recurrence: Optional[Union[int, List[str]]] = SetDefaults.schedule_recurrence,
+        only_new_assets: bool = SetDefaults.only_new_assets,
+        on_count_above: Optional[int] = SetDefaults.on_count_above,
+        on_count_below: Optional[int] = SetDefaults.on_count_below,
+        on_count_increased: bool = SetDefaults.on_count_increased,
+        on_count_decreased: bool = SetDefaults.on_count_decreased,
+    ):
+        """Pass."""
+        trigger = Schedule.get_trigger(
+            query_uuid=query_uuid,
+            query_type=query_type,
+            schedule_type=schedule_type,
+            schedule_hour=schedule_hour,
+            schedule_minute=schedule_minute,
+            schedule_recurrence=schedule_recurrence,
+            only_new_assets=only_new_assets,
+            on_count_above=on_count_above,
+            on_count_below=on_count_below,
+            on_count_increased=on_count_increased,
+            on_count_decreased=on_count_decreased,
+        )
+        self.triggers = [trigger]
+
+    def get_basic(self, refresh: bool = False) -> SetBasic:
+        """Pass."""
+        if self.BASIC and not refresh:
+            return self.BASIC
+
+        from .. import ApiEndpoints
+
+        api_endpoint = ApiEndpoints.enforcements.get_sets
+        request_obj = api_endpoint.load_request(
+            filter=f'name == "{self.name}"',
+            search=f"{self.name}",
+        )
+        result = api_endpoint.perform_request(http=self.HTTP, request_obj=request_obj)
+        if not result:
+            raise NotFoundError(f"Unable to find Enforcement Set with name of {self.name!r}")
+
+        self.BASIC = result[0]
+        return self.BASIC
+
+    @staticmethod
+    def get_action_obj(name: str, action_type: "ActionType", config: dict) -> dict:
+        """Pass."""
+        return {
+            "name": name,
+            "action": {"action_name": action_type.name, "config": config},
+        }
+
+    def check_trigger_exists(self, msg: str) -> bool:
+        """Pass."""
+        if not self._trigger_obj:
+            raise NoTriggerDefinedError(
+                f"Unable to {msg} - Enforcement Set with Name of {self.name!r}"
+                f" and UUID of {self.uuid!r}) has no trigger configured"
+            )
+
+    def check_action_category(self, category: Union[ActionCategory, str]) -> ActionCategory:
+        """Pass."""
+        category = ActionCategory.get_value(category)
+
+        if category.value not in self.actions:
+            self.actions[category.value] = []
+        return category
+
+    def query_remove(self):
+        """Pass."""
+        self.check_trigger_exists("remove query")
+        self.triggers = []
+
+    def query_update(self, query_uuid: str, query_type: str = SetDefaults.query_type):
+        """Pass."""
+        if self._trigger_obj:
+            self._trigger_obj["view"] = Schedule.get_view(
+                query_uuid=query_uuid, query_type=query_type
+            )
+        else:
+            self.set_trigger(query_uuid=query_uuid, query_type=query_type)
+
+    def set_schedule_never(self):
+        """Pass."""
+        self.check_trigger_exists("set schedule to never")
+        self._trigger_obj["period"] = str(Schedule.never)
+        self._trigger_obj["period_time"] = self._trigger_obj.get("period_time", Schedule.get_time())
+        self._trigger_obj.pop("period_recurrence", None)
+
+    def set_schedule_discovery(self):
+        """Pass."""
+        self.check_trigger_exists("set schedule to discovery")
+        self._trigger_obj["period"] = str(Schedule.discovery)
+        self._trigger_obj["period_time"] = self._trigger_obj.get("period_time", Schedule.get_time())
+        self._trigger_obj.pop("period_recurrence", None)
+
+    def set_schedule_hourly(self, recurrence: int):
+        """Pass."""
+        self.check_trigger_exists(f"set schedule to hourly hours {recurrence!r}")
+        period_recurrence = Schedule.calc_hourly(value=recurrence)
+
+        self._trigger_obj["period"] = str(Schedule.hourly)
+        self._trigger_obj["period_time"] = self._trigger_obj.get("period_time", Schedule.get_time())
+        self._trigger_obj["period_recurrence"] = period_recurrence
+
+    def set_schedule_daily(
+        self,
+        recurrence: int,
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ):
+        """Pass."""
+        self.check_trigger_exists(
+            f"set schedule to daily days {recurrence!r} hour {hour!r} minute {minute!r}"
+        )
+        period_recurrence = Schedule.calc_daily(value=recurrence)
+        period_time = Schedule.get_time(hour=hour, minute=minute)
+
+        self._trigger_obj["period"] = str(Schedule.daily)
+        self._trigger_obj["period_time"] = period_time
+        self._trigger_obj["period_recurrence"] = period_recurrence
+
+    def set_schedule_weekly(
+        self,
+        recurrence: Union[str, List[Union[str, int]]],
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ):
+        """Pass."""
+        self.check_trigger_exists(
+            f"set schedule to weekly days {recurrence!r} hour {hour!r} minute {minute!r}"
+        )
+        period_recurrence = Schedule.calc_weekly(value=recurrence)
+        period_time = Schedule.get_time(hour=hour, minute=minute)
+
+        self._trigger_obj["period"] = str(Schedule.weekly)
+        self._trigger_obj["period_time"] = period_time
+        self._trigger_obj["period_recurrence"] = period_recurrence
+
+    def set_schedule_monthly(
+        self,
+        recurrence: Union[str, List[int]],
+        hour: int = SetDefaults.schedule_hour,
+        minute: int = SetDefaults.schedule_minute,
+    ):
+        """Pass."""
+        self.check_trigger_exists(
+            f"set schedule to monthly days {recurrence!r} hour {hour!r} minute {minute!r}"
+        )
+        period_recurrence = Schedule.calc_monthly(value=recurrence)
+        period_time = Schedule.get_time(hour=hour, minute=minute)
+
+        self._trigger_obj["period"] = str(Schedule.monthly)
+        self._trigger_obj["period_time"] = period_time
+        self._trigger_obj["period_recurrence"] = period_recurrence
+
+    def add_action(self, category: str, action: dict):
+        """Pass."""
+        category = self.check_action_category(category=category)
+        self.actions[category.value].append(action)
+
+    def remove_action(self, category: str, name: str):
+        """Pass."""
+        category = self.check_action_category(category=category)
+        matches = [x for x in self.actions[category.value] if x["name"] == name]
+        if not matches:
+            valids = json_dump(self.actions[category.value])
+            raise NotFoundError(
+                f"No {category} actions found with name of {name!r}, valids:\n{valids}"
+            )
+
+        self.actions[category.value] = [x for x in self.actions[category.value] if x not in matches]
+
+    @property
+    def main_action(self) -> dict:
+        """Get the main action object."""
+        return self.actions["main"]
+
+    @main_action.setter
+    def main_action(self, action: dict):
+        """Pass."""
+        self.actions["main"] = action
+
+    @property
+    def failure_actions(self) -> List[dict]:
+        """Pass."""
+        return self.actions.get(ActionCategory.failure.value) or []
+
+    @property
+    def success_actions(self) -> List[dict]:
+        """Pass."""
+        return self.actions.get(ActionCategory.success.value) or []
+
+    @property
+    def post_actions(self) -> List[dict]:
+        """Pass."""
+        return self.actions.get(ActionCategory.post.value) or []
+
+    @property
+    def main_action_str(self) -> str:
+        """Pass."""
+        return self._get_action_str(value=self.main_action, category="main")
+
+    @property
+    def failure_actions_str(self) -> List[str]:
+        """Pass."""
+        return [
+            self._get_action_str(value=x, category=ActionCategory.failure.value, idx=idx)
+            for idx, x in enumerate(self.failure_actions)
+        ]
+
+    @property
+    def success_actions_str(self) -> List[str]:
+        """Pass."""
+        return [
+            self._get_action_str(value=x, category=ActionCategory.success.value, idx=idx)
+            for idx, x in enumerate(self.success_actions)
+        ]
+
+    @property
+    def post_actions_str(self) -> List[str]:
+        """Pass."""
+        return [
+            self._get_action_str(value=x, category=ActionCategory.post.value, idx=idx)
+            for idx, x in enumerate(self.post_actions)
+        ]
+
+    @property
+    def schedule_type(self) -> Optional[str]:
+        """Pass."""
+        return self._schedule_type.name if self._schedule_type else None
+
+    @property
+    def query_type(self) -> Optional[str]:
+        """Pass."""
+        return self._trigger_view_obj.get("entity", None)
+
+    # BASIC MODEL attribute
+    @property
+    def query_name(self) -> Optional[str]:
+        """Pass."""
+        return self.get_basic().query_name
+
+    # BASIC MODEL attribute
+    @property
+    def triggered_last_date(self) -> Optional[datetime.datetime]:
+        """Pass."""
+        return self.get_basic().triggered_last_date
+
+    # BASIC MODEL attribute
+    @property
+    def triggered_count(self) -> Optional[int]:
+        """Pass."""
+        return self.get_basic().triggered_count
+
+    # BASIC MODEL attribute
+    @property
+    def schedule(self) -> Optional[str]:
+        """Pass."""
+        return self.get_basic().schedule
+
+    # BASIC MODEL attribute
+    @property
+    def updated_date(self) -> datetime.datetime:
+        """Pass."""
+        return self.get_basic().last_updated
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_obj(self) -> dict:
+        """Pass."""
+        return self.get_basic().updated_user_obj
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_name(self) -> str:
+        """Get the user name of the user that last updated this set."""
+        return self.get_basic().updated_user_name
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_source(self) -> str:
+        """Get the source of the user that last updated this set."""
+        return self.get_basic().updated_user_source
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_first_name(self) -> str:
+        """Get the first name of the user that last updated this set."""
+        return self.get_basic().updated_user_first_name
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_last_name(self) -> str:
+        """Get the last name of the user that last updated this set."""
+        return self.get_basic().updated_user_last_name
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user_full_name(self) -> str:
+        """Get the first and last name of the user that last updated this set."""
+        return self.get_basic().updated_user_full_name
+
+    # BASIC MODEL attribute
+    @property
+    def updated_user(self) -> str:
+        """Pass."""
+        return self.get_basic().updated_user
+
+    @property
+    def only_new_assets(self) -> Optional[bool]:
+        """Pass."""
+        return OnlyNewAssets.get_bool(value=self._trigger_obj.get("run_on"))
+
+    @only_new_assets.setter
+    def only_new_assets(self, value: bool):
+        """Pass."""
+        self.check_trigger_exists(f"set only_new_assets to {value}")
+        self._trigger_obj["run_on"] = OnlyNewAssets.get_str(value)
+
+    @property
+    def on_count_above(self) -> Optional[int]:
+        """Pass."""
+        return self._trigger_conditions_obj.get("above")
+
+    @on_count_above.setter
+    def on_count_above(self, value: Optional[int]):
+        """Pass."""
+        self.check_trigger_exists(f"set on_count_above to {value}")
+        self._trigger_obj["conditions"]["above"] = coerce_int(
+            obj=value,
+            allow_none=True,
+            min_value=0,
+            errmsg="on_count_above must be an integer above 0 or None",
+        )
+
+    @property
+    def on_count_below(self) -> Optional[int]:
+        """Pass."""
+        return self._trigger_conditions_obj.get("below")
+
+    @on_count_below.setter
+    def on_count_below(self, value: Optional[int]):
+        """Pass."""
+        self.check_trigger_exists(f"set on_count_below to {value}")
+        self._trigger_obj["conditions"]["below"] = coerce_int(
+            obj=value,
+            allow_none=True,
+            min_value=0,
+            errmsg="on_count_below must be an integer above 0 or None",
+        )
+
+    @property
+    def on_count_increased(self) -> Optional[bool]:
+        """Pass."""
+        return self._trigger_conditions_obj.get("new_entities")
+
+    @on_count_increased.setter
+    def on_count_increased(self, value: bool):
+        """Pass."""
+        self.check_trigger_exists(f"set on_count_increased to {value}")
+        self._trigger_obj["conditions"]["new_entities"] = coerce_bool(
+            obj=value, errmsg="on_count_increased must be a boolean"
+        )
+
+    @property
+    def on_count_decreased(self) -> Optional[bool]:
+        """Pass."""
+        return self._trigger_conditions_obj.get("previous_entities")
+
+    @on_count_decreased.setter
+    def on_count_decreased(self, value: bool):
+        """Pass."""
+        self.check_trigger_exists(f"set on_count_decreased to {value}")
+        self._trigger_obj["conditions"]["previous_entities"] = coerce_bool(
+            obj=value, errmsg="on_count_decreased must be a boolean"
+        )
+
+    def to_tablize(self):
+        """Pass."""
+        ident = [
+            f"Name: {self.name!r}",
+            f"UUID: {self.uuid!r}",
+            f"Updated Date: {self.updated_date}",
+            f"Updated User: {self.updated_user!r}",
+        ]
+        details = [
+            self.main_action_str,
+            *self.success_actions_str,
+            *self.failure_actions_str,
+            *self.post_actions_str,
+            f"Query Name: {self.query_name!r}",
+            f"Query Type: {self.query_type!r}",
+            f"Schedule: {self.schedule}",
+            f"Schedule Type: {self.schedule_type}",
+            f"Only New Assets: {self.only_new_assets}",
+            f"On Count Above: {self.on_count_above}",
+            f"On Count Below: {self.on_count_below}",
+            f"On Count Increased: {self.on_count_increased}",
+            f"On Count Decreased: {self.on_count_decreased}",
+            f"Triggered Last Date: {self.triggered_last_date}",
+            f"Triggered Count: {self.triggered_count}",
+        ]
+        return {
+            "Identifier": "\n".join(ident),
+            "Details": "\n".join(details),
+        }
+
+    @staticmethod
+    def _get_action_str(value: dict, category: str, idx: Optional[int] = None) -> str:
+        """Pass."""
+        name = value["name"]
+        atype = value["action"]["action_name"]
+        pre = f"{category.title()} Action"
+        if isinstance(idx, int):
+            pre = f"{pre} #{idx +1}"
+        return f"{pre} {name!r} ({atype})"
+
+    @property
+    def _trigger_conditions_obj(self) -> dict:
+        """Pass."""
+        return self._trigger_obj.get("conditions", {})
+
+    @property
+    def _trigger_view_obj(self) -> dict:
+        """Pass."""
+        return self._trigger_obj.get("view", {})
+
+    @property
+    def _trigger_obj(self) -> dict:
+        """Pass."""
+        return self.triggers[0] if self.triggers else {}
+
+    @property
+    def _trigger_period(self) -> str:
+        """Pass."""
+        return self._trigger_obj.get("period", "")
+
+    @property
+    def _schedule_type(self) -> Optional[Schedule]:
+        """Pass."""
+        period = self._trigger_obj.get("period", "")
+        if period:
+            return Schedule.get_value(value=period)
+        return None
+
+    def __str__(self) -> str:
+        """Pass."""
+        items = [
+            f"Name: {self.name!r}",
+            f"UUID: {self.uuid!r}",
+            self.main_action_str,
+            *self.success_actions_str,
+            *self.failure_actions_str,
+            *self.post_actions_str,
+            f"Query Name: {self.query_name}",
+            f"Query Type: {self.query_type}",
+            f"Schedule: {self.schedule}",
+            f"Schedule Type: {self.schedule_type}",
+            f"Only New Assets: {self.only_new_assets}",
+            f"On Count Above: {self.on_count_above}",
+            f"On Count Below: {self.on_count_below}",
+            f"On Count Increased: {self.on_count_increased}",
+            f"On Count Decreased: {self.on_count_decreased}",
+            f"Triggered Last Date: {self.triggered_last_date}",
+            f"Triggered Count: {self.triggered_count}",
+            f"Updated Date: {self.updated_date}",
+            f"Updated User: {self.updated_user}",
+        ]
+        return "\n".join(items)
+
+    def __repr__(self):
+        """Pass."""
+        return self.__str__()
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return SetFullSchema
+
+
+class UpdateRequestSchema(BaseSchemaJson):
+    """Pass."""
+
+    name = marshmallow_jsonapi.fields.Str()
+    uuid = marshmallow_jsonapi.fields.Str()
+    actions = marshmallow_jsonapi.fields.Dict()
+    triggers = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Dict())
+
+    class Meta:
+        """Pass."""
+
+        type_ = "enforcements_schema"
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return UpdateRequest
+
+
+@dataclasses.dataclass
+class UpdateRequest(BaseModel):
+    """Pass."""
+
+    id: str
+    uuid: str
+    name: str
     actions: dict
     triggers: List[dict]
 
     @staticmethod
-    def get_schema_cls() -> Optional[Type[BaseSchema]]:  # pragma: no cover
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
-        return EnforcementSchema
+        return UpdateRequestSchema
+
+
+class UpdateResponseSchema(BaseSchemaJson):
+    """Pass."""
+
+    name = marshmallow_jsonapi.fields.Str()
+    uuid = marshmallow_jsonapi.fields.Str()
+    actions = marshmallow_jsonapi.fields.Dict()
+    triggers = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Dict())
+
+    class Meta:
+        """Pass."""
+
+        type_ = "enforcements_details_schema"
 
     @staticmethod
-    def _str_properties() -> List[str]:  # pragma: no cover
+    def get_model_cls() -> type:
         """Pass."""
-        return [
-            "name",
-            "uuid",
-        ]
+        return UpdateResponse
 
 
-class EnforcementCreateSchema(BaseSchemaJson):  # pragma: no cover
+@dataclasses.dataclass
+class UpdateResponse(BaseModel):
+    """Pass."""
+
+    id: str
+    name: str
+    actions: dict
+    triggers: List[dict]
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return UpdateResponseSchema
+
+    @property
+    def uuid(self) -> str:
+        """Pass."""
+        return self.id
+
+
+class DuplicateSchema(BaseSchemaJson):
+    """Pass."""
+
+    uuid = marshmallow_jsonapi.fields.Str()
+    name = marshmallow_jsonapi.fields.Str()
+    clone_triggers = marshmallow_jsonapi.fields.Bool(load_default=True, dump_default=True)
+
+    class Meta:
+        """Pass."""
+
+        type_ = "duplicate_enforcements_schema"
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return Duplicate
+
+
+@dataclasses.dataclass
+class Duplicate(BaseModel):
+    """Pass."""
+
+    id: str
+    uuid: str
+    name: str
+    clone_triggers: bool = True
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return DuplicateSchema
+
+
+class CreateSchema(BaseSchemaJson):
     """Pass."""
 
     name = marshmallow_jsonapi.fields.Str()
@@ -166,13 +1058,13 @@ class EnforcementCreateSchema(BaseSchemaJson):  # pragma: no cover
         type_ = "enforcements_schema"
 
     @staticmethod
-    def get_model_cls() -> type:  # pragma: no cover
+    def get_model_cls() -> type:
         """Pass."""
-        return EnforcementCreate
+        return Create
 
 
 @dataclasses.dataclass
-class EnforcementCreate(BaseModel):  # pragma: no cover
+class Create(BaseModel):
     """Pass."""
 
     name: str
@@ -180,15 +1072,15 @@ class EnforcementCreate(BaseModel):  # pragma: no cover
     triggers: List[dict]
 
     @staticmethod
-    def get_schema_cls() -> Optional[Type[BaseSchema]]:  # pragma: no cover
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
-        return EnforcementCreateSchema
+        return CreateSchema
 
 
-class ActionSchema(BaseSchemaJson):  # pragma: no cover
+class ActionTypeSchema(BaseSchemaJson):
     """Pass."""
 
-    default = marshmallow_jsonapi.fields.Dict()
+    default = marshmallow_jsonapi.fields.Dict(allow_none=True)
     schema = marshmallow_jsonapi.fields.Dict()
 
     class Meta:
@@ -197,25 +1089,113 @@ class ActionSchema(BaseSchemaJson):  # pragma: no cover
         type_ = "actions_schema"
 
     @staticmethod
-    def get_model_cls() -> type:  # pragma: no cover
+    def get_model_cls() -> type:
         """Pass."""
-        return Action
+        return ActionType
 
 
 @dataclasses.dataclass
-class Action(BaseModel):  # pragma: no cover
+class ActionType(BaseModel):
     """Pass."""
 
     id: str
-    default: dict
     schema: dict
+    default: Optional[dict] = None
 
     @staticmethod
-    def get_schema_cls() -> Optional[Type[BaseSchema]]:  # pragma: no cover
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
-        return ActionSchema
+        return ActionTypeSchema
+
+    def to_tablize(self) -> dict:
+        """Pass."""
+        return {"Name": self.name, "Config Keys": "\n".join(self.names)}
 
     @property
-    def name(self):  # pragma: no cover
+    def items(self) -> List[dict]:
+        """Pass."""
+        return self.schema.get("items", [])
+
+    @property
+    def required(self) -> List[str]:
+        """Pass."""
+        return self.schema.get("required", [])
+
+    @property
+    def names(self) -> List[str]:
+        """Pass."""
+        return [x["name"] for x in self.items]
+
+    @property
+    def conditional_schema(self) -> Optional[dict]:
+        """Pass."""
+        if "conditional" in self.names:
+            return [x for x in self.items if x["name"] == "conditional"][0]
+        return None
+
+    @property
+    def conditional_items(self) -> List[dict]:
+        """Pass."""
+        schema = self.conditional_schema
+        return [x for x in schema["enum"]] if schema else []
+
+    @property
+    def conditional_names(self) -> List[str]:
+        """Pass."""
+        return [x["name"] for x in self.conditional_items]
+
+    @property
+    def name(self) -> str:
         """Pass."""
         return self.id
+
+    def get_required_conditionally(self, config: Optional[dict] = None) -> List[str]:
+        """Pass."""
+        config = {} if config is None else config
+        remove_requireds = []
+        schema = self.conditional_schema
+        if schema and schema["name"] in config:
+            key = schema["name"]
+            value = config[key]
+            remove_requireds = [y for y in self.conditional_names if y != value]
+            return [x for x in self.required if x not in remove_requireds]
+        return self.required
+
+    def check_config(self, config: Optional[dict] = None) -> dict:
+        """Pass."""
+        config = {} if config is None else config
+        if not isinstance(config, dict):
+            raise ApiError(f"Action config must be a dict, not {type(config)}")
+
+        config = self.check_config_unknown(config=config)
+        config = self.check_config_missing(config=config)
+        return config
+
+    def check_config_missing(self, config: Optional[dict] = None) -> dict:
+        """Pass."""
+        config = {} if config is None else config
+        required = self.get_required_conditionally(config=config)
+        missing = [x for x in self.names if x in required and x not in config]
+
+        if missing:
+            err = f"Action config missing required items: {missing}"
+            raise ConfigRequired("\n\n".join([err, json_dump(self), err]))
+        return config
+
+    def check_config_unknown(self, config: Optional[dict] = None) -> dict:
+        """Pass."""
+        config = {} if config is None else config
+        unknowns = [x for x in config if x not in self.names]
+
+        if unknowns:
+            err = f"Action config has unknown items: {unknowns}"
+            raise ConfigUnknown("\n\n".join([err, json_dump(self), err]))
+        return config
+
+    def __str__(self):
+        """Pass."""
+        return f"name={self.name!r}, config_keys={self.names}"
+
+    def __repr__(self):
+        """Pass."""
+        return self.__str__()

--- a/axonius_api_client/api/json_api/resources.py
+++ b/axonius_api_client/api/json_api/resources.py
@@ -92,7 +92,8 @@ class ResourcesGetSchema(BaseSchemaJson):
 
     sort = marshmallow_jsonapi.fields.Str(allow_none=True, load_default=None, dump_default=None)
     page = marshmallow_jsonapi.fields.Nested(PaginationSchema)
-    search = marshmallow_jsonapi.fields.Str(allow_none=True, load_default=None, dump_default=None)
+    search = marshmallow_jsonapi.fields.Str(load_default="", dump_default="")
+    filter = marshmallow_jsonapi.fields.Str(allow_none=True, load_default="", dump_default="")
     get_metadata = SchemaBool(load_default=True, dump_default=True)
 
     @staticmethod
@@ -103,15 +104,15 @@ class ResourcesGetSchema(BaseSchemaJson):
     class Meta:
         """Pass."""
 
-        type_ = "resource_base_schema"
+        type_ = "resource_request_schema"
 
 
 @dataclasses.dataclass
 class ResourcesGet(PageSortRequest):
     """Request attributes for getting resources."""
 
-    search: Optional[str] = dataclasses.field(
-        default=None,
+    search: str = dataclasses.field(
+        default="",
         metadata={
             "dataclasses_json": {
                 "mm_field": marshmallow_jsonapi.fields.Str(load_default="", dump_default="")
@@ -126,6 +127,16 @@ class ResourcesGet(PageSortRequest):
         (name == regex("test", "i"))
         (name == regex("test", "i")) and tags in ["Linux"]
     """
+    filter: Optional[str] = dataclasses.field(
+        default=None,
+        metadata={
+            "dataclasses_json": {
+                "mm_field": marshmallow_jsonapi.fields.Str(
+                    allow_none=True, load_default="", dump_default=""
+                )
+            },
+        },
+    )
 
     @staticmethod
     def get_schema_cls() -> Optional[Type[BaseSchema]]:

--- a/axonius_api_client/api/system/instances.py
+++ b/axonius_api_client/api/system/instances.py
@@ -448,6 +448,16 @@ class Instances(ModelMixins):
         return response.to_dict()
 
     @property
+    def api_version(self) -> str:
+        """Pass."""
+        return self._get_api_version().value
+
+    @property
+    def api_versions(self) -> List[str]:
+        """Pass."""
+        return [x.value for x in self._get_api_versions()]
+
+    @property
     @cachetools.cached(cache=FEATURE_FLAGS_CACHE)
     def feature_flags(self) -> json_api.system_settings.FeatureFlags:
         """Get the feature flags for the core."""
@@ -687,3 +697,10 @@ class Instances(ModelMixins):
 
         response = api_endpoint.perform_request(http=self.auth.http, uuid=uuid)
         return response
+
+    def _get_api_version(self) -> json_api.generic.StrValueSchema:
+        """Pass."""
+        return ApiEndpoints.instances.get_api_version.perform_request(http=self.auth.http)
+
+    def _get_api_versions(self) -> json_api.generic.StrValueSchema:
+        return ApiEndpoints.instances.get_api_versions.perform_request(http=self.auth.http)

--- a/axonius_api_client/cli/__init__.py
+++ b/axonius_api_client/cli/__init__.py
@@ -22,7 +22,16 @@ from ..constants.logs import (
     RESPONSE_ATTR_MAP,
 )
 from ..logs import LOG
-from . import context, grp_adapters, grp_assets, grp_certs, grp_openapi, grp_system, grp_tools
+from . import (
+    context,
+    grp_adapters,
+    grp_assets,
+    grp_certs,
+    grp_enforcements,
+    grp_openapi,
+    grp_system,
+    grp_tools,
+)
 
 
 @click.group(
@@ -337,3 +346,4 @@ cli.add_command(grp_system.system)
 cli.add_command(grp_tools.tools)
 cli.add_command(grp_openapi.openapi)
 cli.add_command(grp_certs.certs)
+cli.add_command(grp_enforcements.enforcements)

--- a/axonius_api_client/cli/grp_enforcements/__init__.py
+++ b/axonius_api_client/cli/grp_enforcements/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+import click
+
+from ..context import AliasedGroup, load_cmds
+
+
+@click.group(cls=AliasedGroup)
+def enforcements():
+    """Group: Work with the Enforcement Center."""
+
+
+load_cmds(path=__file__, package=__package__, group=enforcements)

--- a/axonius_api_client/cli/grp_enforcements/cmd_copy.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_copy.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_COPY_TRIGGERS,
+    OPT_EXPORT_FORMAT,
+    OPT_NEW_NAME,
+    OPT_SET_VALUE_REQ,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_NEW_NAME, OPT_COPY_TRIGGERS, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="copy", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Copy an Enforcement Set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.copy(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_create.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_create.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPTS_CREATE
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, *OPTS_CREATE]
+
+
+@click.command(name="create", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, main_action_config, **kwargs):
+    """Create an Enforcement Set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+    kwargs["main_action_config"] = ctx.obj.read_stream_json(stream=main_action_config, expect=dict)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.create(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_delete.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_delete.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="delete", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Delete an Enforcement Set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.delete(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_get.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_get.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_OPT
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_SET_VALUE_OPT]
+
+
+@click.command(name="get", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, value):
+    """Get Enforcement Sets."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        if value:
+            data = client.enforcements.get_set(value=value)
+        else:
+            data = client.enforcements.get_sets()
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_get_action_types.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_get_action_types.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_ACTION_VALUE_OPT, OPT_EXPORT_FORMAT
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_ACTION_VALUE_OPT]
+
+
+@click.command(name="get-action-types", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, value):
+    """Get Action Types."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        if value:
+            data = client.enforcements.get_action_type(value=value)
+        else:
+            data = client.enforcements.get_action_types()
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_action_add.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_action_add.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_ACTION_CATEGORY,
+    OPT_EXPORT_FORMAT,
+    OPT_SET_VALUE_REQ,
+    OPTS_ACTION_ADD,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_ACTION_CATEGORY, *OPTS_ACTION_ADD, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-action-add", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, config, **kwargs):
+    """Add an action to a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+    kwargs["config"] = ctx.obj.read_stream_json(stream=config, expect=dict)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_action_add(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_action_main.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_action_main.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPTS_ACTION_ADD
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, *OPTS_ACTION_ADD, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-action-main", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, config, **kwargs):
+    """Update the main action of a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+    kwargs["config"] = ctx.obj.read_stream_json(stream=config, expect=dict)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_action_main(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_action_remove.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_action_remove.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_ACTION_CATEGORY,
+    OPT_ACTION_NAME,
+    OPT_EXPORT_FORMAT,
+    OPT_SET_VALUE_REQ,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_ACTION_CATEGORY, OPT_ACTION_NAME, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-action-remove", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Remove an action from a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_action_remove(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_name.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_name.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_NEW_NAME, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_NEW_NAME, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-name", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update the name of a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_name(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_above.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_above.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPT_UPDATE_INT
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_UPDATE_INT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-on-count-above", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update only run when asset count is above N."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_on_count_above(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_below.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_below.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPT_UPDATE_INT
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_UPDATE_INT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-on-count-below", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update only run when asset count is below N."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_on_count_below(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_decreased.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_decreased.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPT_UPDATE_BOOL
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_UPDATE_BOOL, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-on-count-decreased", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update only run when asset count decreases."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_on_count_decreased(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_increased.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_on_count_increased.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPT_UPDATE_BOOL
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_UPDATE_BOOL, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-on-count-increased", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update only run when asset count increases."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_on_count_increased(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_only_new_assets.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_only_new_assets.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPT_UPDATE_BOOL
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_UPDATE_BOOL, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-only-new-assets", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update only run against new assets."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_only_new_assets(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_query.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_query.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ, OPTS_UPDATE_QUERY
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, *OPTS_UPDATE_QUERY, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-query", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update the query of a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_query(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_query_remove.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_query_remove.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-query-remove", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Remove the query from a set."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_query_remove(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_daily.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_daily.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_EXPORT_FORMAT,
+    OPT_RECURRENCE_DAILY,
+    OPT_SET_VALUE_REQ,
+    OPTS_SCHEDULE_TIME,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_RECURRENCE_DAILY, *OPTS_SCHEDULE_TIME, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-daily", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to run daily."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_daily(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_discovery.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_discovery.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-discovery", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to run on discovery."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_discovery(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_hourly.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_hourly.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_RECURRENCE_HOURLY, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_RECURRENCE_HOURLY, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-hourly", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to run hourly."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_hourly(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_monthly.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_monthly.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_EXPORT_FORMAT,
+    OPT_RECURRENCE_MONTHLY,
+    OPT_SET_VALUE_REQ,
+    OPTS_SCHEDULE_TIME,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_RECURRENCE_MONTHLY, *OPTS_SCHEDULE_TIME, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-monthly", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to run monthly."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_monthly(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_never.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_never.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-never", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to never run."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_never(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_weekly.py
+++ b/axonius_api_client/cli/grp_enforcements/cmd_update_schedule_weekly.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..options import AUTH, add_options
+from .grp_common import (
+    EXPORT_FORMATS,
+    OPT_EXPORT_FORMAT,
+    OPT_RECURRENCE_WEEKLY,
+    OPT_SET_VALUE_REQ,
+    OPTS_SCHEDULE_TIME,
+)
+
+OPTIONS = [*AUTH, OPT_EXPORT_FORMAT, OPT_RECURRENCE_WEEKLY, *OPTS_SCHEDULE_TIME, OPT_SET_VALUE_REQ]
+
+
+@click.command(name="update-schedule-weekly", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, **kwargs):
+    """Update a set to run weekly."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.enforcements.update_schedule_weekly(**kwargs)
+
+    click.secho(EXPORT_FORMATS[export_format](data=data))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_enforcements/grp_common.py
+++ b/axonius_api_client/cli/grp_enforcements/grp_common.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...api.json_api.enforcements import ActionCategory, QueryType, Schedule, SetDefaults
+from ...parsers.tables import tablize
+from ...tools import json_dump
+from ..context import click
+
+OPT_RECURRENCE_DAILY = click.option(
+    "--recurrence",
+    "-r",
+    "recurrence",
+    help="Set schedule to run every N days (N = int 1-~), ex: '7'",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_RECURRENCE_HOURLY = click.option(
+    "--recurrence",
+    "-r",
+    "recurrence",
+    help="Set schedule to run every N hours (N = int 1-24), ex: '4'",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_RECURRENCE_WEEKLY = click.option(
+    "--recurrence",
+    "-r",
+    "recurrence",
+    help="Set schedule to run on N days of week (N = int 0-6 or day of week), ex: '0,wednesday'",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_RECURRENCE_MONTHLY = click.option(
+    "--recurrence",
+    "-r",
+    "recurrence",
+    help="Set schedule to run on N days of month (N = int 1-29), ex: '1,4,29'",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_UPDATE_BOOL = click.option(
+    "--enable/--disable",
+    "-e/-d",
+    "update",
+    required=True,
+    help="Enable/disable option",
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_UPDATE_INT = click.option(
+    "--int",
+    "-i",
+    "update",
+    required=True,
+    help="Integer to assign to option ('none' for None)",
+    show_envvar=True,
+    show_default=True,
+)
+
+
+OPT_SET_VALUE_OPT = click.option(
+    "--value",
+    "-v",
+    "value",
+    help="Name or UUID of Enforcement Set",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_SET_VALUE_REQ = click.option(
+    "--value",
+    "-v",
+    "value",
+    help="Name or UUID of Enforcement Set",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_ACTION_VALUE_OPT = click.option(
+    "--value",
+    "-v",
+    "value",
+    help="Name or UUID of Action Type",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+
+
+OPT_NEW_NAME = click.option(
+    "--name",
+    "-n",
+    "name",
+    help="New Name to assign",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_COPY_TRIGGERS = click.option(
+    "--copy-triggers/--no-copy-triggers",
+    "-ct/-nct",
+    "copy_triggers",
+    default=True,
+    help="Include triggers in copy",
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_ACTION_CATEGORY = click.option(
+    "--category",
+    "-cat",
+    "category",
+    help="Action Category",
+    type=click.Choice(ActionCategory.keys()),
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_ACTION_NAME = click.option(
+    "--name",
+    "-an",
+    "name",
+    help="Name of the Action",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPTS_SCHEDULE_TIME = [
+    click.option(
+        "--schedule-hour",
+        "-sh",
+        "schedule_hour",
+        help="Hour to use for schedule",
+        default=SetDefaults.schedule_hour,
+        type=click.INT,
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--schedule-minute",
+        "-sm",
+        "schedule_minute",
+        help="Minute to use for schedule",
+        default=SetDefaults.schedule_minute,
+        type=click.INT,
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+]
+OPTS_ACTION_ADD = [
+    OPT_ACTION_NAME,
+    click.option(
+        "--type",
+        "-at",
+        "action_type",
+        help="Type of Action",
+        required=True,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--config",
+        "-ac",
+        "config",
+        help="JSON file with the configuration for the Action",
+        required=True,
+        default="-",
+        type=click.File(mode="r"),
+        show_envvar=True,
+        show_default=True,
+    ),
+]
+OPTS_UPDATE_QUERY = [
+    click.option(
+        "--query-name",
+        "-qn",
+        "query_name",
+        help="Name of Saved Query to use for trigger",
+        default=SetDefaults.query_name,
+        required=True,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--query-type",
+        "-qt",
+        "query_type",
+        help="Type of Saved Query to use for trigger",
+        type=click.Choice(QueryType.keys()),
+        default=SetDefaults.query_type,
+        required=True,
+        show_envvar=True,
+        show_default=True,
+    ),
+]
+OPTS_CREATE = [
+    OPT_NEW_NAME,
+    click.option(
+        "--main-action-name",
+        "-man",
+        "main_action_name",
+        help="Name of the Main Action",
+        required=True,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--main-action-type",
+        "-mat",
+        "main_action_type",
+        help="Type of action for the Main Action",
+        required=True,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--main-action-config",
+        "-mac",
+        "main_action_config",
+        help="JSON file with the configuration for the Main Action",
+        required=True,
+        default="-",
+        type=click.File(mode="r"),
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--query-name",
+        "-qn",
+        "query_name",
+        help="Name of Saved Query to use for trigger",
+        default=SetDefaults.query_name,
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--query-type",
+        "-qt",
+        "query_type",
+        help="Type of Saved Query to use for trigger",
+        type=click.Choice(QueryType.keys()),
+        default=SetDefaults.query_type,
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--schedule-type",
+        "-st",
+        "schedule_type",
+        help="Type of Schedule to use for trigger",
+        default=SetDefaults.schedule_type,
+        type=click.Choice(Schedule.keys()),
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+    *OPTS_SCHEDULE_TIME,
+    click.option(
+        "--schedule-recurrence",
+        "-sr",
+        "schedule_recurrence",
+        help=(
+            "Recurrence of schedule type: hourly (int 1-24), daily (int 1-~), "
+            "weekly (CSV of days as int 0-6 or day names), monthly (CSV of days as int 1-29)"
+        ),
+        default=SetDefaults.schedule_recurrence,
+        required=False,
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--only-new-assets/--no-only-new-assets",
+        "-ona/-nona",
+        "only_new_assets",
+        default=SetDefaults.only_new_assets,
+        help="Configure trigger to only run against new assets",
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--on-count-increased/--no-on-count-increased",
+        "-oci/-noci",
+        "on_count_increased",
+        default=SetDefaults.on_count_increased,
+        help="Configure trigger to only run when Saved Query asset count increases",
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--on-count-decreased/--no-on-count-decreased",
+        "-ocd/-nocd",
+        "on_count_decreased",
+        default=SetDefaults.on_count_decreased,
+        help="Configure trigger to only run when Saved Query asset count decreases",
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--on-count-above",
+        "-oca",
+        "on_count_above",
+        default=SetDefaults.on_count_above,
+        help="Configure trigger to only run when Saved Query asset count is above this number",
+        show_envvar=True,
+        show_default=True,
+    ),
+    click.option(
+        "--on-count-below",
+        "-ocb",
+        "on_count_below",
+        default=SetDefaults.on_count_below,
+        help="Configure trigger to only run when Saved Query asset count is below this number",
+        show_envvar=True,
+        show_default=True,
+    ),
+]
+
+
+def export_set_json(data, **kwargs):
+    """Pass."""
+    return json_dump(data)
+
+
+def export_set_table(data, **kwargs):
+    """Pass."""
+    items = [x.to_tablize() for x in data] if isinstance(data, list) else [data.to_tablize()]
+    return tablize(items)
+
+
+def export_set_str(data, **kwargs):
+    """Pass."""
+    items = [str(x) for x in data] if isinstance(data, list) else [str(data)]
+    return "\n\n".join(items)
+
+
+EXPORT_FORMATS: dict = {
+    "table": export_set_table,
+    "json": export_set_json,
+    "str": export_set_str,
+}
+
+OPT_EXPORT_FORMAT = click.option(
+    "--export-format",
+    "-xf",
+    "export_format",
+    type=click.Choice(list(EXPORT_FORMATS)),
+    help="Format of to export data in",
+    default=list(EXPORT_FORMATS)[0],
+    show_envvar=True,
+    show_default=True,
+)

--- a/axonius_api_client/constants/logs.py
+++ b/axonius_api_client/constants/logs.py
@@ -48,6 +48,8 @@ LOG_LEVEL_WIZARD: str = "debug"
 LOG_LEVEL_PACKAGE: str = "debug"
 """default logging level for the entire package"""
 
+LOG_LEVEL_PARSE: str = "debug"
+
 LOG_LEVELS_STR: List[str] = ["debug", "info", "warning", "error", "fatal"]
 """list of valid logging level strs"""
 

--- a/axonius_api_client/data.py
+++ b/axonius_api_client/data.py
@@ -3,7 +3,9 @@
 import dataclasses
 import datetime
 import enum
-from typing import List
+from typing import List, Union
+
+from .exceptions import ApiError
 
 
 class BaseEnum(enum.Enum):
@@ -16,6 +18,34 @@ class BaseEnum(enum.Enum):
     def __str__(self):
         """Pass."""
         return str(self.value)
+
+    @classmethod
+    def get_value(cls, value: Union["BaseEnum", str]) -> "BaseEnum":
+        """Pass."""
+        if isinstance(value, cls):
+            return value
+
+        for item in cls:
+            if value in [item.name, item.value]:
+                return item
+
+        valids = "\n" + "\n".join([repr(x) for x in cls])
+        raise ApiError(f"Invalid {cls.__name__} value {value!r}, valids:{valids}")
+
+    @classmethod
+    def keys(cls) -> List[str]:
+        """Pass."""
+        return [x.name for x in cls]
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """Pass."""
+        return [x.value for x in cls]
+
+    @classmethod
+    def to_dict(cls) -> dict:
+        """Pass."""
+        return {x.name: x.value for x in cls}
 
 
 @dataclasses.dataclass

--- a/axonius_api_client/exceptions.py
+++ b/axonius_api_client/exceptions.py
@@ -226,6 +226,10 @@ class ApiAttributeMissingError(ApiAttributeError):
     """Pass."""
 
 
+class NoTriggerDefinedError(ApiError):
+    """Pass."""
+
+
 class StopFetch(ApiError):
     """Pass."""
 

--- a/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
+++ b/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
@@ -2,15 +2,13 @@
 """Test suite."""
 
 import pytest
-
 from axonius_api_client.api import json_api
 from axonius_api_client.constants.adapters import CSV_ADAPTER
 from axonius_api_client.exceptions import (
-    CnxAddError,
+    CnxAddError,  # ConfigRequired,
     CnxTestError,
     CnxUpdateError,
     ConfigInvalidValue,
-    ConfigRequired,
     ConfigUnchanged,
     NotFoundError,
 )
@@ -18,6 +16,7 @@ from axonius_api_client.tools import combo_dicts
 
 from ...meta import CSV_FILECONTENT_STR, CsvData, CsvKeys, TanData, TanKeys
 from ...utils import get_cnx_existing, get_cnx_working
+
 
 """
 cnx errors
@@ -330,9 +329,9 @@ class TestCnxPublic(TestCnxBase):
                 password=mpass,
             )
 
-    def test_test_fail_no_domain(self, apiobj):
-        with pytest.raises(ConfigRequired):
-            apiobj.cnx.test(adapter_name="tanium", username="x")
+    # def test_test_fail_no_domain(self, apiobj):
+    #     with pytest.raises(ConfigRequired):
+    #         apiobj.cnx.test(adapter_name="tanium", username="x")
 
     def test_cb_file_upload_fail(self, apiobj, csv_file_path, monkeypatch):
         mock_return = {"filename": "badwolf", "uuid": "badwolf"}

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_csv.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_csv.py
@@ -32,7 +32,7 @@ class TestCallbacksCsv(Callbacks, Exports):
         cbobj = self.get_cbobj(
             apiobj=apiobj,
             cbexport=cbexport,
-            store={"fields": [field_complex]},
+            store={"fields_parsed": [field_complex]},
             getargs={"export_fd": io_fd, "export_fd_close": False},
         )
         cbobj.start()
@@ -63,7 +63,7 @@ class TestCallbacksCsv(Callbacks, Exports):
         cbobj = self.get_cbobj(
             apiobj=apiobj,
             cbexport=cbexport,
-            store={"fields": apiobj.fields_default},
+            store={"fields_parsed": apiobj.fields_default},
             getargs={"export_fd": io_fd, "field_titles": False, "export_fd_close": False},
         )
         cbobj.start()

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json_to_csv.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json_to_csv.py
@@ -24,7 +24,7 @@ class TestCallbacksJsonToCsv(Callbacks, Exports):
         cbobj = self.get_cbobj(
             apiobj=apiobj,
             cbexport=cbexport,
-            store={"fields": apiobj.fields_default},
+            store={"fields_parsed": apiobj.fields_default},
             getargs={"export_fd": io_fd, "export_fd_close": False},
         )
         cbobj.start()

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_table.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_table.py
@@ -5,7 +5,6 @@ import copy
 import io
 
 import pytest
-
 from axonius_api_client.exceptions import ApiError, StopFetch
 
 from ...utils import get_rows_exist, get_schema
@@ -35,7 +34,7 @@ class TestCallbacksTable(Callbacks, Exports):
         cbobj = self.get_cbobj(
             apiobj=apiobj,
             cbexport=cbexport,
-            store={"fields": [field_complex]},
+            store={"fields_parsed": [field_complex]},
             getargs={"export_fd": io_fd, "export_fd_close": False, "table_max_rows": 4},
         )
         cbobj.start()

--- a/axonius_api_client/tests/tests_api/tests_assets/test_fields.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_fields.py
@@ -3,7 +3,6 @@
 import copy
 
 import pytest
-
 from axonius_api_client.api import json_api
 from axonius_api_client.constants.fields import AGG_ADAPTER_ALTS, AGG_ADAPTER_NAME
 from axonius_api_client.exceptions import ApiError, NotFoundError
@@ -154,6 +153,10 @@ class FieldsPrivate:
 
             part_of_table = field.pop("part_of_table", False)
             assert isinstance(part_of_table, bool)
+
+            # 2022-04-09 {'flatten': True}
+            flatten = field.pop("flatten", False)
+            assert isinstance(flatten, bool)
 
             assert not field, list(field)
 
@@ -401,6 +404,10 @@ class FieldsPublic:
 
         part_of_table = schema.pop("part_of_table", False)
         assert isinstance(part_of_table, bool)
+
+        # 2022-04-09 {'flatten': True}
+        flatten = schema.pop("flatten", False)
+        assert isinstance(flatten, bool)
 
         if is_complex:
             if name != "all" and not name.endswith("raw_data"):

--- a/axonius_api_client/tests/tests_api/tests_assets/test_labels.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_labels.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test suite for axonapi.api.assets."""
 import pytest
-
 from axonius_api_client.api import json_api
 
 
@@ -15,6 +14,7 @@ class LabelsPrivate:
 
     def test_private_add_get_remove(self, apiobj):
         labels = ["badwolf1", "badwolf2"]
+        labels_str = ",".join(labels)
 
         # get a single asset to add a label to
         asset = apiobj.get(max_rows=1)[0]
@@ -26,7 +26,8 @@ class LabelsPrivate:
         assert add_label_result.value == 1
 
         # re-get the asset and check that it has the label
-        assets_added = apiobj.get_by_values(values=labels, field="labels", fields="labels")
+        wiz_entries = f"simple labels in {labels_str}"
+        assets_added = apiobj.get(wiz_entries=wiz_entries, fields="labels", max_rows=1)
         assets_added_ids = [x["internal_axon_id"] for x in assets_added]
         assert asset_id in assets_added_ids
 
@@ -52,8 +53,13 @@ class LabelsPrivate:
         assert remove_label_result.value >= 1
 
         # re-get the asset and check that it has the label
-        assets_removed = apiobj.get_by_values(values=labels, field="labels", fields="labels")
-        assert not assets_removed
+        wiz_entries = f"simple internal_axon_id equals {asset_id}"
+        assets_removed = apiobj.get(wiz_entries=wiz_entries, fields="labels", max_rows=1)
+
+        # check the each label has been removed
+        for x in assets_removed:
+            for label in labels:
+                assert label not in x.get("labels", [])
 
         # check that the label is not in all the labels on the system
         all_labels_post_remove = apiobj.labels._get()
@@ -72,6 +78,7 @@ class LabelsPublic:
 
     def test_add_get_remove(self, apiobj):
         labels = ["badwolf1", "badwolf2"]
+        labels_str = ",".join(labels)
 
         # get a single asset to add a label to
         asset = apiobj.get(max_rows=1)[0]
@@ -82,11 +89,8 @@ class LabelsPublic:
         assert add_label_result == 1
 
         # re-get the asset and check that it has the label
-        assets_added = apiobj.get_by_values(
-            values=labels,
-            field="labels",
-            fields="labels",
-        )
+        wiz_entries = f"simple labels in {labels_str}"
+        assets_added = apiobj.get(wiz_entries=wiz_entries, fields="labels", max_rows=1)
         assets_added_ids = [x["internal_axon_id"] for x in assets_added]
         assert asset_id in assets_added_ids
 
@@ -110,8 +114,12 @@ class LabelsPublic:
         assert remove_label_result >= 1
 
         # re-get the asset and check that it has the label
-        assets_removed = apiobj.get_by_values(values=labels, field="labels", fields="labels")
-        assert not assets_removed
+        wiz_entries = f"simple internal_axon_id equals {asset_id}"
+        assets_removed = apiobj.get(wiz_entries=wiz_entries, fields="labels", max_rows=1)
+        # check the each label has been removed
+        for x in assets_removed:
+            for label in labels:
+                assert label not in x.get("labels", [])
 
         # check that the label is not in all the labels on the system
         all_labels_post_remove = apiobj.labels.get()

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -13,6 +13,7 @@ from axonius_api_client.exceptions import (
     ApiAttributeTypeError,
     ApiError,
     GuiQueryWizardWarning,
+    ResponseNotOk,
     SavedQueryNotFoundError,
 )
 
@@ -47,6 +48,8 @@ class SavedQueryPrivate:
     def test_add(self, apiobj):
         name = "badwolfvvv"
         view = {
+            "colExcludedAdapters": [],
+            "colFilters": [],
             "query": {
                 "filter": "",
                 "expressions": [],
@@ -200,8 +203,13 @@ class SavedQueryPublic:
     def test_update_private(self, apiobj, sq_fixture):
         old_value = sq_fixture["private"]
         new_value = not old_value
-        updated = apiobj.saved_query.update_private(sq=sq_fixture, value=new_value)
-        assert updated["private"] == new_value
+        if old_value:
+            updated = apiobj.saved_query.update_private(sq=sq_fixture, value=new_value)
+            assert updated["private"] == new_value
+        else:
+            with pytest.raises(ResponseNotOk) as exc:
+                apiobj.saved_query.update_private(sq=sq_fixture, value=new_value)
+            assert "Can't change a public query to be a private query." in str(exc.value)
 
     def test_update_description(self, apiobj, sq_fixture):
         add = random_string(6)

--- a/axonius_api_client/tests/tests_api/tests_enforcements/test_enforcements.py
+++ b/axonius_api_client/tests/tests_api/tests_enforcements/test_enforcements.py
@@ -1,105 +1,525 @@
 # -*- coding: utf-8 -*-
-"""Test suite for axonapi.api.enforcements."""
-'''
-# XXX need to re-flush EC!
+"""Test suite."""
 import pytest
+from axonius_api_client.api.json_api.enforcements import (
+    ActionCategory,
+    ActionType,
+    OnlyNewAssets,
+    QueryType,
+    Schedule,
+    SetBasic,
+    SetFull,
+)
+from axonius_api_client.exceptions import (
+    ApiError,
+    ApiWarning,
+    ConfigRequired,
+    ConfigUnknown,
+    NotFoundError,
+    NoTriggerDefinedError,
+    ToolsError,
+)
 
-# from axonius_api_client.exceptions import NotFoundError
 
-# from ...meta import CREATE_EC_ACTION_MAIN, CREATE_EC_NAME, CREATE_EC_TRIGGER1
+class Meta:
+    name = "badwolf EC"
+    name_cli = "Badwolf FROM CLI"
+    name_copy = "yan badwolf EC"
+    name_rename = "badwolf vittles"
+    name_rename_cli = "badwolf vittles CLI"
+    name_invalid = "i do not exist"
+    name_create = "badwolf created"
+
+    action_type = "create_notification"
+
+    action_name = "badwolf action"
+    action_name2 = "badwolf action 2"
+
+    action_config = {}
 
 
-class TestEnforcementsBase:
+class EnforcementsBase:
     @pytest.fixture(scope="class")
     def apiobj(self, api_enforcements):
         return api_enforcements
 
-
-class TestEnforcementsPrivate(TestEnforcementsBase):
-    def test_private_get(self, apiobj):
-        data = apiobj._get()
-        assert isinstance(data, dict)
-
-        assets = data["assets"]
-        assert isinstance(assets, list)
-
-        for asset in assets:
-            assert isinstance(asset, dict)
-
-
-class TestEnforcementsPublic(TestEnforcementsBase):
-    def test_get(self, apiobj):
-        data = apiobj.get()
-        assert isinstance(data, list)
-        for found in data:
-            assert isinstance(found["uuid"], str)
-            assert isinstance(found["actions.main"], str)
-            assert isinstance(found["name"], str)
-            assert isinstance(found["date_fetched"], str)
-            assert isinstance(found["last_updated"], str)
-            assert "triggers.last_triggered" in found
-            assert "triggers.times_triggered" in found
-
-    def test_get_maxpages(self, apiobj):
-        found = apiobj.get(max_pages=1, page_size=1)
-        assert isinstance(found, list)
-        # we can't test for length if there are no enforcements...
-        # assert len(found) == 1
-
-    def test_create_get_delete(self, apiobj, api_users):
+    @pytest.fixture(scope="class")
+    def created_set(self, apiobj):
         try:
-            old_found = apiobj.get_by_name(CREATE_EC_NAME, eq_single=False)
-        except Exception:
-            old_found = None
+            created_set = apiobj.get_set(value=Meta.name)
+        except NotFoundError:
+            with pytest.warns(ApiWarning):
+                created_set = apiobj.create(
+                    name=Meta.name,
+                    main_action_type=Meta.action_type,
+                    main_action_name=Meta.action_name,
+                    main_action_config=Meta.action_config,
+                )
+
+        assert isinstance(created_set, SetFull)
+
+        yield created_set
+
+        deleted = self.cleanup(apiobj=apiobj, value=created_set)
+        assert isinstance(deleted, SetFull)
+
+    def cleanup(self, apiobj, value):
+        try:
+            deleted = apiobj.delete(value=value)
+        except NotFoundError:
+            pass
         else:
-            deleted = apiobj.delete(rows=old_found)
-            assert isinstance(deleted, dict)
-            assert isinstance(deleted["deleted"], int)
-            assert deleted["deleted"] == 1
+            print(f"Deleted Enforcement Set:\n{deleted}")
+            return deleted
 
-        trigger_name = api_users.saved_query.get()[0]["name"]
-        trigger = {"view": {"name": trigger_name, "entity": "users"}}
-        trigger.update(CREATE_EC_TRIGGER1)
 
-        created = apiobj._create(
-            name=CREATE_EC_NAME, main=CREATE_EC_ACTION_MAIN, triggers=[trigger],
+class TestEnforcements(EnforcementsBase):
+    def test_create_delete(self, apiobj):
+        self.cleanup(apiobj=apiobj, value=Meta.name_create)
+        with pytest.warns(ApiWarning):
+            created_set = apiobj.create(
+                name=Meta.name_create,
+                main_action_type=Meta.action_type,
+                main_action_name=Meta.action_name,
+                main_action_config=Meta.action_config,
+            )
+
+        assert isinstance(created_set, SetFull)
+        assert isinstance(created_set.BASIC, SetBasic)
+
+        basic = created_set.get_basic(refresh=True)
+        assert isinstance(basic, SetBasic)
+
+        deleted = apiobj.delete(value=created_set)
+        assert isinstance(deleted, SetFull)
+        assert isinstance(deleted.BASIC, SetBasic)
+
+        with pytest.raises(NotFoundError):
+            deleted.get_basic(refresh=True)
+
+    def test_attach_full_set_bad_type(self, apiobj):
+        with pytest.raises(ApiError):
+            apiobj.attach_full_set({})
+
+    def test_get_action_type_bad_type(self, apiobj):
+        with pytest.raises(ApiError):
+            apiobj.get_action_type(value=4)
+
+    def test_get_action_types(self, apiobj):
+        value = apiobj.get_action_types()
+        for x in value:
+            assert isinstance(x, ActionType)
+
+    def test_get_action_type(self, apiobj):
+        action_type = apiobj.get_action_type(value=Meta.action_type)
+        assert isinstance(action_type, ActionType)
+        value = apiobj.get_action_type(value=action_type)
+        assert value == action_type
+        value = apiobj.get_action_type(value=action_type.to_dict())
+        assert value == action_type
+
+    def test_get_action_type_not_found(self, apiobj):
+        with pytest.raises(NotFoundError):
+            apiobj.get_action_type(value=Meta.name_invalid)
+
+    def test_get_sets(self, created_set, apiobj):
+        value = apiobj.get_sets()
+        assert created_set.uuid in [x.uuid for x in value]
+
+    def test_get_set(self, created_set, apiobj):
+        value = apiobj.get_set(value=created_set)
+        assert (value.name, value.uuid) == (created_set.name, created_set.uuid)
+        value = apiobj.get_set(value=created_set.to_dict())
+        assert (value.name, value.uuid) == (created_set.name, created_set.uuid)
+        value = apiobj.get_set(value=created_set.uuid)
+        assert (value.name, value.uuid) == (created_set.name, created_set.uuid)
+        value = apiobj.get_set(value=created_set.name)
+        assert (value.name, value.uuid) == (created_set.name, created_set.uuid)
+
+    def test_get_set_action_get_required_conditionally_no_key(self, apiobj):
+        atype = apiobj.get_action_type("add_custom_data")
+        exp = ["field_name", "conditional", "field_value", "field_on", "field_list", "field_date"]
+        value = atype.get_required_conditionally()
+        assert value == exp
+
+    def test_get_set_action_get_required_conditionally_with_key(self, apiobj):
+        atype = apiobj.get_action_type("add_custom_data")
+        exp = ["field_name", "conditional", "field_value"]
+        value = atype.get_required_conditionally(config={"conditional": "field_value"})
+        assert value == exp
+
+    def test_get_set_action_no_schema(self, apiobj):
+        atypes = apiobj.get_action_types()
+        atype = [x for x in atypes if not x.schema][0]
+
+        exp = {"name": "boobear", "action": {"action_name": atype.name, "config": {}}}
+
+        with pytest.warns(ApiWarning):
+            value = apiobj.get_set_action(action_type=atype, name="boobear")
+        assert value == exp
+
+    def test_get_set_action_invalid_type(self, apiobj):
+        atypes = apiobj.get_action_types()
+        atype = [x for x in atypes if x.schema][0]
+
+        with pytest.raises(ApiError):
+            apiobj.get_set_action(action_type=atype, name="boobear", config="1")
+
+    def test_get_set_action_missing_required(self, apiobj):
+        atypes = apiobj.get_action_types()
+        atype = [x for x in atypes if x.schema][0]
+
+        with pytest.raises(ConfigRequired):
+            apiobj.get_set_action(action_type=atype, name="boobear", config={})
+
+    def test_get_set_action_unknown(self, apiobj):
+        atypes = apiobj.get_action_types()
+        atype = [x for x in atypes if x.schema][0]
+
+        with pytest.raises(ConfigUnknown):
+            apiobj.get_set_action(action_type=atype, name="boobear", config={"k": "v"})
+
+    def test_update_add_remove_action(self, created_set, apiobj):
+        action_name = "yan badwolf"
+        with pytest.warns(ApiWarning):
+            added = apiobj.update_action_add(
+                value=created_set,
+                category=ActionCategory.failure,
+                name=action_name,
+                action_type=Meta.action_type,
+                config=Meta.action_config,
+            )
+        assert isinstance(added, SetFull)
+        assert action_name in " ".join(added.failure_actions_str)
+
+        removed = apiobj.update_action_remove(
+            value=added, category=ActionCategory.failure, name=action_name
         )
-        assert isinstance(created, str)
+        assert action_name not in " ".join(removed.failure_actions_str)
 
-        found = apiobj.get_by_name(CREATE_EC_NAME)
-        """
-        {
-            "actions.main": "Badwolf Create Notification",
-            "date_fetched": "2019-09-10 23:17:07+00:00",
-            "last_updated": "Tue, 10 Sep 2019 23:17:07 GMT",
-            "name": "Badwolf EC Example",
-            "triggers.last_triggered": null,
-            "triggers.times_triggered": 0,
-            "triggers.view.name": "Users Created in Last 30 Days",
-            "uuid": "5d782ef380ded0001bbe3c47"
+    def test_update_conditions(self, created_set, apiobj):
+        sq = apiobj.api_devices.saved_query.get(as_dataclass=True)[0]
+        if not created_set.query_name:
+            updated = apiobj.update_query(value=created_set, query_name=sq, query_type="devices")
+            assert updated.query_name
+
+        updated = apiobj.update_only_new_assets(value=created_set, update=True)
+        assert updated.only_new_assets is True
+
+        updated = apiobj.update_on_count_increased(value=created_set, update=True)
+        assert updated.on_count_increased is True
+
+        updated = apiobj.update_on_count_decreased(value=created_set, update=True)
+        assert updated.on_count_decreased is True
+
+        updated = apiobj.update_on_count_above(value=created_set, update=5)
+        assert updated.on_count_above == 5
+
+        updated = apiobj.update_on_count_above(value=created_set, update="None")
+        assert updated.on_count_above is None
+
+        updated = apiobj.update_on_count_above(value=created_set, update="5")
+        assert updated.on_count_above == 5
+
+        updated = apiobj.update_on_count_above(value=created_set, update=None)
+        assert updated.on_count_above is None
+
+        updated = apiobj.update_on_count_below(value=created_set, update=5)
+        assert updated.on_count_below == 5
+
+        updated = apiobj.update_on_count_below(value=created_set, update="None")
+        assert updated.on_count_below is None
+
+        updated = apiobj.update_on_count_below(value=created_set, update="5")
+        assert updated.on_count_below == 5
+
+        updated = apiobj.update_on_count_below(value=created_set, update=None)
+        assert updated.on_count_below is None
+
+    def test_update_schedule(self, created_set, apiobj):
+        sq = apiobj.api_devices.saved_query.get(as_dataclass=True)[0]
+        if created_set.query_name:
+            updated = apiobj.update_query_remove(value=created_set)
+            assert not updated._trigger_obj
+
+        updated = apiobj.update_query(value=created_set, query_name=sq, query_type="devices")
+        assert sq.name in str(updated)
+        assert updated._trigger_obj
+
+        updated = apiobj.update_schedule_never(value=updated)
+        assert "never" in str(updated)
+
+        updated = apiobj.update_schedule_discovery(value=updated)
+        assert "discovery" in str(updated)
+
+        updated = apiobj.update_schedule_hourly(value=updated, recurrence=2)
+        assert "hourly" in str(updated)
+
+        updated = apiobj.update_schedule_daily(value=updated, recurrence=2)
+        assert "daily" in str(updated)
+
+        updated = apiobj.update_schedule_weekly(value=updated, recurrence="2,5")
+        assert "weekly" in str(updated)
+
+        updated = apiobj.update_schedule_monthly(value=updated, recurrence="1,3,6,29")
+        assert "monthly" in str(updated)
+
+        updated = apiobj.update_query_remove(value=updated)
+        assert not updated._trigger_obj
+
+    def test_update_query(self, created_set, apiobj):
+        sq = apiobj.api_devices.saved_query.get(as_dataclass=True)[0]
+        if created_set.query_name:
+            updated = apiobj.update_query_remove(value=created_set)
+            assert not updated._trigger_obj
+
+        updated = apiobj.update_query(value=created_set, query_name=sq, query_type="devices")
+        assert sq.name in str(updated)
+        assert updated._trigger_obj
+
+        updated = apiobj.update_query_remove(value=updated)
+        assert not updated._trigger_obj
+
+    def test_update_no_trigger_failures(self, created_set, apiobj):
+        if created_set.query_name:
+            updated = apiobj.update_query_remove(value=created_set)
+            assert not updated._trigger_obj
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_query_remove(value=created_set)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_never(value=created_set)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_discovery(value=created_set)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_hourly(value=created_set, recurrence=1)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_daily(value=created_set, recurrence=1)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_weekly(value=created_set, recurrence="monday")
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_schedule_monthly(value=created_set, recurrence="1,2,29")
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_only_new_assets(value=created_set, update=True)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_on_count_above(value=created_set, update=1)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_on_count_below(value=created_set, update=1)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_on_count_increased(value=created_set, update=True)
+
+        with pytest.raises(NoTriggerDefinedError):
+            apiobj.update_on_count_decreased(value=created_set, update=True)
+
+    def test_copy_update_name_action(self, created_set, apiobj):
+        copied = apiobj.copy(value=created_set, name=Meta.name_copy)
+        assert copied.name == Meta.name_copy
+
+        self.cleanup(apiobj=apiobj, value=Meta.name_rename)
+        updated = apiobj.update_name(value=copied, name=Meta.name_rename)
+        assert updated.name == Meta.name_rename
+
+        with pytest.warns(ApiWarning):
+            updated = apiobj.update_action_main(
+                value=updated,
+                name=Meta.action_name2,
+                action_type=Meta.action_type,
+                config=Meta.action_config,
+            )
+        assert Meta.action_name2 in str(updated)
+        assert Meta.action_name2 in repr(updated)
+
+        deleted = self.cleanup(apiobj=apiobj, value=updated)
+        assert deleted.name == updated.name
+
+    def test_model_query_remove_no_trigger(self, created_set, apiobj):
+        with pytest.raises(NoTriggerDefinedError):
+            created_set.query_remove()
+
+    def test_model_set_sechedule_never_no_trigger(self, created_set, apiobj):
+        with pytest.raises(NoTriggerDefinedError):
+            created_set.set_schedule_never()
+
+
+class TestOnlyNewAssets:
+    def test_get_str_true(self):
+        assert OnlyNewAssets.get_str(value=True) == str(OnlyNewAssets.added_entities)
+
+    def test_get_str_false(self):
+        assert OnlyNewAssets.get_str(value=False) == str(OnlyNewAssets.all_entities)
+
+    def test_get_bool_none(self):
+        assert OnlyNewAssets.get_bool(value=None) is None
+
+    def test_get_bool_fail(self):
+        with pytest.raises(ApiError):
+            OnlyNewAssets.get_bool(value="x")
+
+    def test_get_bool_true(self):
+        assert OnlyNewAssets.get_bool(value=OnlyNewAssets.added_entities) is True
+        assert OnlyNewAssets.get_bool(value=str(OnlyNewAssets.added_entities)) is True
+
+    def test_get_bool_False(self):
+        assert OnlyNewAssets.get_bool(value=OnlyNewAssets.all_entities) is False
+        assert OnlyNewAssets.get_bool(value=str(OnlyNewAssets.all_entities)) is False
+
+
+class TestQueryType:
+    def test_get_value(self):
+        assert QueryType.get_value("devices") == QueryType.devices
+
+    def test_get_value_fail(self):
+        with pytest.raises(ApiError):
+            QueryType.get_value("x")
+
+
+class TestSchedule:
+    def test_get_value(self):
+        for i in Schedule.keys():
+            value = Schedule.get_value(i)
+            assert value.name == i
+
+        for i in Schedule.values():
+            value = Schedule.get_value(i)
+            assert value.value == i
+            assert str(value) == i
+
+    def test_get_value_fail(self):
+        with pytest.raises(ApiError):
+            Schedule.get_value("x")
+
+    def test_get_time_default(self):
+        value = Schedule.get_time()
+        assert isinstance(value, str) and ":" in value
+
+    def test_get_time(self):
+        value = Schedule.get_time(hour=22, minute=2)
+        assert value == "22:02"
+
+    def test_get_time_hour_fail(self):
+        with pytest.raises(ToolsError):
+            Schedule.get_time(hour=24)
+
+    def test_get_time_minute_fail(self):
+        with pytest.raises(ToolsError):
+            Schedule.get_time(minute=60)
+
+    def test_get_conditions_default(self):
+        value = Schedule.get_conditions()
+        exp = {"new_entities": False, "previous_entities": False, "above": None, "below": None}
+        assert value == exp
+
+    def test_get_conditions(self):
+        value = Schedule.get_conditions(
+            on_count_above="100",
+            on_count_below="5",
+            on_count_increased=True,
+            on_count_decreased=True,
+        )
+        exp = {"new_entities": True, "previous_entities": True, "above": 100, "below": 5}
+        assert value == exp
+
+    def test_get_conditions_fail(self):
+        with pytest.raises(ToolsError):
+            Schedule.get_conditions(on_count_above=-1)
+
+        with pytest.raises(ToolsError):
+            Schedule.get_conditions(on_count_below=-1)
+
+        with pytest.raises(ToolsError):
+            Schedule.get_conditions(on_count_increased="x")
+
+        with pytest.raises(ToolsError):
+            Schedule.get_conditions(on_count_decreased="x")
+
+    def test_get_view_default(self):
+        assert Schedule.get_view() is None
+
+    def test_get_view_fail(self):
+        with pytest.raises(ApiError):
+            Schedule.get_view(query_type="x")
+
+    def test_get_view(self):
+        assert Schedule.get_view(query_uuid="xxx", query_type="users") == {
+            "id": "xxx",
+            "entity": "users",
         }
-        """
-        assert isinstance(found, dict)
-        assert found["uuid"] == created
-        assert found["actions.main"] == CREATE_EC_ACTION_MAIN["name"]
-        assert found["name"] == CREATE_EC_NAME
-        assert isinstance(found["date_fetched"], str)
-        assert isinstance(found["last_updated"], str)
-        assert "triggers.last_triggered" in found
-        assert "triggers.times_triggered" in found
-        assert found["triggers.view.name"] == trigger_name
 
-        found_by_id = apiobj.get_by_uuid(found["uuid"])
-        assert isinstance(found_by_id, dict)
+    def test_get_recurrence_never(self):
+        sched = Schedule.never
+        assert sched.get_recurrence() is None
 
-        deleted = apiobj.delete(rows=found_by_id)
-        assert isinstance(deleted, dict)
-        assert isinstance(deleted["deleted"], int)
-        assert deleted["deleted"] == 1
+    def test_get_recurrence_discovery(self):
+        sched = Schedule.discovery
+        assert sched.get_recurrence() is None
 
-        with pytest.raises(NotFoundError):
-            apiobj.get_by_uuid(found["uuid"])
+    def test_get_recurrence_hourly(self):
+        sched = Schedule.hourly
+        with pytest.raises(ToolsError):
+            sched.get_recurrence()
 
-        with pytest.raises(NotFoundError):
-            apiobj.get_by_name(found["name"])
-'''
+        assert sched.get_recurrence("23") == 23
+
+        with pytest.raises(ToolsError):
+            sched.get_recurrence(25)
+
+    def test_get_recurrence_daily(self):
+        sched = Schedule.daily
+        with pytest.raises(ToolsError):
+            sched.get_recurrence()
+
+        assert sched.get_recurrence("23") == 23
+
+        with pytest.raises(ToolsError):
+            sched.get_recurrence(0)
+
+    def test_get_recurrence_weekly(self):
+        sched = Schedule.weekly
+        with pytest.raises(ToolsError):
+            sched.get_recurrence()
+
+        assert sched.get_recurrence("0,1") == ["0", "1"]
+        assert sched.get_recurrence("Tuesday,Sunday") == ["1", "6"]
+        assert sched.get_recurrence(["Wednesday", "mondaY"]) == ["0", "2"]
+        assert sched.get_recurrence(["3", "MONDAY"]) == ["0", "3"]
+
+        with pytest.raises(ToolsError):
+            sched.get_recurrence("7")
+
+    def test_get_recurrence_monthly(self):
+        sched = Schedule.monthly
+        with pytest.raises(ToolsError):
+            sched.get_recurrence()
+
+        assert sched.get_recurrence("8,1,29") == ["1", "8", "29"]
+        assert sched.get_recurrence(["8", 1, "29"]) == ["1", "8", "29"]
+
+        with pytest.raises(ToolsError):
+            sched.get_recurrence("30")
+
+    def test_get_trigger(self):
+        exp = {
+            "name": "Trigger",
+            "view": None,
+            "period": "never",
+            "period_time": "13:00",
+            "conditions": {
+                "new_entities": False,
+                "previous_entities": False,
+                "above": None,
+                "below": None,
+            },
+            "run_on": "AllEntities",
+        }
+        value = Schedule.get_trigger()
+        assert value == exp

--- a/axonius_api_client/tests/tests_api/tests_json_api/test_json_api.py
+++ b/axonius_api_client/tests/tests_api/tests_json_api/test_json_api.py
@@ -2,7 +2,6 @@ import dataclasses
 
 import marshmallow
 import pytest
-
 from axonius_api_client.api import json_api
 from axonius_api_client.api.json_api.base import BaseModel, BaseSchema, BaseSchemaJson
 from axonius_api_client.exceptions import SchemaError
@@ -209,6 +208,6 @@ class TestJsonApi:
 
     def test_dump_request_params(self):
         data = json_api.resources.ResourcesGet(page={"limit": 20, "offset": 3})
-        exp = {"page[limit]": 20, "page[offset]": 3, "get_metadata": True}
+        exp = {"page[limit]": 20, "page[offset]": 3, "get_metadata": True, "search": ""}
         ret = data.dump_request_params()
         assert ret == exp

--- a/axonius_api_client/tests/tests_cli/tests_grp_enforcements/__init__.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_enforcements/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Test suite."""

--- a/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_copy.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_copy.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import json
+
+import pytest
+from axonius_api_client.cli import cli
+from axonius_api_client.exceptions import ApiWarning
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_enforcements.test_enforcements import EnforcementsBase, Meta
+from ...utils import load_clirunner
+
+
+class TestGrpEnforcementsCmdCopyUpdate(EnforcementsBase):
+    def test_multi(self, request, monkeypatch, apiobj, created_set):
+        self.cleanup(apiobj=apiobj, value=Meta.name_copy)
+        self.cleanup(apiobj=apiobj, value=Meta.name_rename_cli)
+
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            # COPY
+            args = [
+                "enforcements",
+                "copy",
+                "--value",
+                created_set.name,
+                "--name",
+                Meta.name_copy,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert created_set.name in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            # RENAME
+            args = [
+                "enforcements",
+                "update-name",
+                "--value",
+                data["uuid"],
+                "--name",
+                Meta.name_rename_cli,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.name_rename_cli in result.stdout
+            assert Meta.name not in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            # update main action
+            args = [
+                "enforcements",
+                "update-action-main",
+                "--value",
+                data["uuid"],
+                "--name",
+                Meta.action_name2,
+                "--type",
+                Meta.action_type,
+                "--export-format",
+                "json",
+            ]
+            with pytest.warns(ApiWarning):
+                result = runner.invoke(cli=cli, args=args, input=json.dumps(Meta.action_config))
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert data["uuid"] in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            # add success action
+            args = [
+                "enforcements",
+                "update-action-add",
+                "--value",
+                data["uuid"],
+                "--category",
+                "success",
+                "--name",
+                "leafy",
+                "--type",
+                Meta.action_type,
+                "--export-format",
+                "json",
+            ]
+            with pytest.warns(ApiWarning):
+                result = runner.invoke(cli=cli, args=args, input=json.dumps(Meta.action_config))
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert data["uuid"] in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            # remove success action
+            args = [
+                "enforcements",
+                "update-action-remove",
+                "--value",
+                data["uuid"],
+                "--category",
+                "success",
+                "--name",
+                "leafy",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert data["uuid"] in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+        self.cleanup(apiobj=apiobj, value=Meta.name_copy)
+        self.cleanup(apiobj=apiobj, value=Meta.name_rename_cli)

--- a/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_create.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_create.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import json
+
+import pytest
+from axonius_api_client.cli import cli
+from axonius_api_client.exceptions import ApiWarning
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_enforcements.test_enforcements import EnforcementsBase, Meta
+from ...utils import load_clirunner
+
+
+class TestGrpEnforcementsCmdCreateDelete(EnforcementsBase):
+    def test_config_stdin(self, request, monkeypatch, apiobj):
+        self.cleanup(apiobj=apiobj, value=Meta.name_cli)
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "create",
+                "--name",
+                Meta.name_cli,
+                "--main-action-name",
+                Meta.action_name,
+                "--main-action-type",
+                Meta.action_type,
+                "--export-format",
+                "json",
+            ]
+            with pytest.warns(ApiWarning):
+                result = runner.invoke(cli=cli, args=args, input=json.dumps(Meta.action_config))
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.name_cli in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            args = [
+                "enforcements",
+                "delete",
+                "--value",
+                data["name"],
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(
+                cli=cli,
+                args=args,
+            )
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.name_cli in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+        self.cleanup(apiobj=apiobj, value=Meta.name_cli)
+
+    def test_config_file(self, request, monkeypatch, apiobj):
+        self.cleanup(apiobj=apiobj, value=Meta.name_cli)
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            config = "config.json"
+            with open(config, "w") as fh:
+                json.dump(Meta.action_config, fh)
+
+            args = [
+                "enforcements",
+                "create",
+                "--name",
+                Meta.name_cli,
+                "--main-action-name",
+                Meta.action_name,
+                "--main-action-type",
+                Meta.action_type,
+                "--main-action-config",
+                config,
+                "--export-format",
+                "json",
+            ]
+            with pytest.warns(ApiWarning):
+                result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.name_cli in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+            args = [
+                "enforcements",
+                "delete",
+                "--value",
+                data["name"],
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(
+                cli=cli,
+                args=args,
+            )
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.name_cli in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+        self.cleanup(apiobj=apiobj, value=Meta.name_cli)

--- a/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_get.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_get.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+from axonius_api_client.cli import cli
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_enforcements.test_enforcements import EnforcementsBase
+from ...utils import load_clirunner
+
+
+class TestGrpEnforcementsCmdGet(EnforcementsBase):
+    def test_json_export(self, request, monkeypatch, created_set):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert created_set.name in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, list) and data
+            for x in data:
+                assert isinstance(x, dict) and x
+
+    @pytest.mark.parametrize("export_format", ["str", "table"])
+    def test_str_exports(self, request, monkeypatch, created_set, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get",
+                "--export-format",
+                export_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert created_set.name in result.stdout
+
+    def test_single_json_export(self, request, monkeypatch, created_set):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get",
+                "--value",
+                created_set.name,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert created_set.name in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+    @pytest.mark.parametrize("export_format", ["str", "table"])
+    def test_single_str_exports(self, request, monkeypatch, created_set, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get",
+                "--value",
+                created_set.name,
+                "--export-format",
+                export_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert created_set.name in result.stdout

--- a/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_get_action_types.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_enforcements/test_cmd_get_action_types.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+from axonius_api_client.cli import cli
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_enforcements.test_enforcements import EnforcementsBase, Meta
+from ...utils import load_clirunner
+
+
+class TestGrpEnforcementsCmdGetActionTypes(EnforcementsBase):
+    def test_json_export(self, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get-action-types",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.action_type in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, list) and data
+            for x in data:
+                assert isinstance(x, dict) and x
+
+    @pytest.mark.parametrize("export_format", ["str", "table"])
+    def test_str_exports(self, request, monkeypatch, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get-action-types",
+                "--export-format",
+                export_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.action_type in result.stdout
+
+    def test_single_json_export(self, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get-action-types",
+                "--value",
+                Meta.action_type,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.action_type in result.stdout
+
+            data = json_load(result.stdout)
+            assert isinstance(data, dict) and data
+
+    @pytest.mark.parametrize("export_format", ["str", "table"])
+    def test_single_str_exports(self, request, monkeypatch, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "enforcements",
+                "get-action-types",
+                "--value",
+                Meta.action_type,
+                "--export-format",
+                export_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+            assert Meta.action_type in result.stdout

--- a/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_add_from_json.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_add_from_json.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test suite for axonius_api_client.tools."""
 import pytest
-
 from axonius_api_client.tools import json_dump
 
 from ....cli import cli
@@ -99,8 +98,8 @@ class GrpSavedQueryCmdAddFromJson:
 
         self._cleanup(apiobj=apiobj, value=name)
 
-    def test_exists_overwrite_true_failure(self, apiobj, request, monkeypatch, sq_get):
-        data = sq_get.to_dict()
+    def test_exists_overwrite_true_failure(self, apiobj, request, monkeypatch, sq_added):
+        data = sq_added.to_dict()
         data["view"] = {}
 
         content = json_dump(data)
@@ -127,8 +126,8 @@ class GrpSavedQueryCmdAddFromJson:
             missing = [x for x in exps if x not in result.stderr]
             assert not missing, missing
 
-    def test_exists_overwrite_false(self, apiobj, request, monkeypatch, sq_get):
-        content = json_dump(sq_get)
+    def test_exists_overwrite_false(self, apiobj, request, monkeypatch, sq_added):
+        content = json_dump(sq_added)
         runner = load_clirunner(request, monkeypatch)
         with runner.isolated_filesystem():
             args = [
@@ -150,8 +149,8 @@ class GrpSavedQueryCmdAddFromJson:
             missing = [x for x in exps if x not in result.stderr]
             assert not missing, missing
 
-    def test_exists_overwrite_true(self, apiobj, request, monkeypatch, sq_get):
-        content = json_dump(sq_get)
+    def test_exists_overwrite_true(self, apiobj, request, monkeypatch, sq_added):
+        content = json_dump(sq_added)
         runner = load_clirunner(request, monkeypatch)
         with runner.isolated_filesystem():
             args = [

--- a/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_updates.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_updates.py
@@ -62,8 +62,8 @@ class GrpSavedQueryCmdUpdates:
                 "json",
             ]
             result = runner.invoke(cli=cli, args=args)
-            data = self.check_result(result=result)
-            assert data["private"] is True
+            assert result.exit_code != 0
+            assert "Can't change a public query to be a private query." in result.stderr
 
     def test_cmd_update_name_success(self, apiobj, request, monkeypatch, sq_added):
         value_new = "manananlskafdjl"

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.20.5"
+__version__ = "4.30.0"
 VERSION: str = __version__
 """Version of package."""
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest
 pytest-cov
 pytest-httpbin
+werkzeug==2.0.3


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.30.0](#4205)
    - [AXONSHELL](#axonshell)
        - [AXONSHELL bugfixes](#axonshell-bugfixes)

<!-- /MarkdownTOC -->

# 4.30.0

## AXONSHELL

### AXONSHELL enhancements

- NEW COMMAND GROUP: axonshell enforcements - work with enforcement center
  - axonshell enforcements copy - Copy an Enforcement Set.
  - axonshell enforcements create - Create an Enforcement Set.
  - axonshell enforcements delete - Delete an Enforcement Set.
  - axonshell enforcements get - Get Enforcement Sets.
  - axonshell enforcements get-action-types - Get Action Types.
  - axonshell enforcements update-action-add - Add an action to a set.
  - axonshell enforcements update-action-main - Update the main action of a set.
  - axonshell enforcements update-action-remove - Remove an action from a set.
  - axonshell enforcements update-name - Update the name of a set.
  - axonshell enforcements update-on-count-above - Update only run when asset count is above N.
  - axonshell enforcements update-on-count-below - Update only run when asset count is below N.
  - axonshell enforcements update-on-count- - Update only run when asset count decreases.
  - axonshell enforcements update-on-count- - Update only run when asset count increases.
  - axonshell enforcements update-only-new-assets - Update only run against new assets.
  - axonshell enforcements update-query - Update the query of a set.
  - axonshell enforcements update-query-remove - Remove the query from a set.
  - axonshell enforcements update-schedule-daily - Update a set to run daily.
  - axonshell enforcements update-schedule- - Update a set to run on discovery.
  - axonshell enforcements update-schedule-hourly - Update a set to run hourly.
  - axonshell enforcements update-schedule-monthly - Update a set to run monthly.
  - axonshell enforcements update-schedule-never - Update a set to never run.
  - axonshell enforcements update-schedule-weekly - Update a set to run weekly.

## API Library

### API Library Enhancements
- client.enforcements: reworked completely, methods:
  - client.enforcements.attach_full_set - get the full details of an enforcement set and attach the basic details
  - client.enforcements.check_set_exists - check if an enforcement set exists with the given name
  - client.enforcements.copy - duplicate an enforcement set
  - client.enforcements.create - create an enforcement set
  - client.enforcements.delete - delete an enforcement set
  - client.enforcements.get_action_type - get a single action type
  - client.enforcements.get_action_types - get all action types
  - client.enforcements.get_set - get a single enforcement set
  - client.enforcements.get_set_action - create an action object for inclusion in an enforcement set
  - client.enforcements.get_sets - get all enforcement sets
  - client.enforcements.get_sets_generator - get all enforcement sets using a generator
  - client.enforcements.get_trigger_view - get the associated saved query name and type for inclusion in an enforcement set
  - client.enforcements.update_action_add - add an action to an action category (post, sucesss, failure) for an enforcement set
  - client.enforcements.update_action_main - update the main action of an enforcement set
  - client.enforcements.update_action_remove - remove an action from an action category (post, sucesss, failure) for an enforcement set
  - client.enforcements.update_from_model - update an enforcement set
  - client.enforcements.update_name - update the name of an enforcement set
  - client.enforcements.update_on_count_above - update the on_count_above condition for an enforcement set
  - client.enforcements.update_on_count_below - update the on_count_below condition for an enforcement set
  - client.enforcements.update_on_count_decreased - update the on_count_decreased condition for an enforcement set
  - client.enforcements.update_on_count_increased - update the on_count_increased condition for an enforcement set
  - client.enforcements.update_only_new_assets - update the only_new_assets condition for an enforcement set
  - client.enforcements.update_query - update the saved query name and type for an enforcement set
  - client.enforcements.update_query_remove - remove the saved query trigger from an enforcement set
  - client.enforcements.update_schedule_daily - change the schedule to run daily for an enforcement set
  - client.enforcements.update_schedule_discovery - change the schedule to run every discovery for an enforcement set
  - client.enforcements.update_schedule_hourly - change the schedule to run hourly for an enforcement set
  - client.enforcements.update_schedule_monthly - change the schedule to run monthly for an enforcement set
  - client.enforcements.update_schedule_never - change the schedule to never run for an enforcement set
  - client.enforcements.update_schedule_weekly - change the schedule to run weekly for an enforcement set
  - client.enforcements._copy - private method to copy an enforcement set
  - client.enforcements._create - private method to create an enforcement set
  - client.enforcements._delete - private method to delete an enforcement set
  - client.enforcements._get_action_types - private method to get action types
  - client.enforcements._get_set - private method to get an enforcement set by UUID
  - client.enforcements._get_sets - private method to get all enforcement sets
  - client.enforcements._triggers_map - map of trigger query types to api objects
  - client.enforcements._update - private method to update an enforcement set

- client.instances: new methods:
  - client.instances.api_version - get the current API version of the REST API
  - client.instances.api_versions - get all available API versions of the REST API
  - client.instances._get_api_version - private method to get current API version of the REST API
  - client.instances._get_api_versions - private method to get all available versions of the REST API