### PR TITLE
4.30.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,60 +19,35 @@ init:
 
 
 pip_install_tools:
-	pip install \
-		--quiet \
-		--upgrade \
-		--requirement requirements-pkg.txt
+	pip install --quiet --upgrade --requirement requirements-pkg.txt
 
 pip_install_dev:
-	pip install \
-		--quiet \
-		--upgrade \
-		--requirement requirements-dev.txt
+	pip install --quiet --upgrade --requirement requirements-dev.txt
+	# later versions of werkzeug break pytest
+	pip install --quiet --upgrade werkzeug==2.0.3
 
 pip_install_lint:
-	pip install \
-		--quiet \
-		--upgrade \
-		--requirement requirements-lint.txt
+	pip install --quiet --upgrade --requirement requirements-lint.txt
 
 pip_install_build:
-	pip install \
-		--quiet \
-		--upgrade \
-		--requirement requirements-build.txt
+	pip install --quiet --upgrade --requirement requirements-build.txt
 
 pip_install_docs:
-	pip install \
-		--quiet \
-		--upgrade \
-		--requirement docs/requirements.txt
+	pip install --quiet --upgrade --requirement docs/requirements.txt
 
 pipenv_init:
-	pipenv install \
-		--dev \
-		--skip-lock
+	pipenv install --dev --skip-lock
 
 pipenv_init_ver:
-	pipenv install \
-		--dev \
-		--skip-lock \
-		--python $(PYVER)
+	pipenv install --dev --skip-lock --python $(PYVER)
 
 pipenv_clean:
 	pipenv --rm || true
 
 lint:
-	pipenv run isort \
-		$(PACKAGE) setup.py shell.py
-	pipenv run black \
-		-l 100 \
-		$(PACKAGE) setup.py shell.py
-	pipenv run flake8 \
-		--max-line-length 100 \
-		--exclude $(PACKAGE)/tests \
-		--exclude $(PACKAGE)/examples \
-		$(PACKAGE) setup.py shell.py
+	pipenv run isort $(PACKAGE) setup.py shell.py
+	pipenv run black -l 100 $(PACKAGE) setup.py shell.py
+	pipenv run flake8 --max-line-length 100 --exclude $(PACKAGE)/tests --exclude $(PACKAGE)/examples $(PACKAGE) setup.py shell.py
 	# XXX DISABLED FOR NOW
 	# 	pipenv run pydocstyle \
 	# 		--match-dir='(?!tests).*'\

--- a/axonius_api_client/api/__init__.py
+++ b/axonius_api_client/api/__init__.py
@@ -10,6 +10,7 @@ from .openapi import OpenAPISpec
 from .system import (
     ActivityLogs,
     Dashboard,
+    DataScopes,
     Instances,
     Meta,
     RemoteSupport,
@@ -49,4 +50,5 @@ __all__ = (
     "ApiEndpoint",
     "json_api",
     "OpenAPISpec",
+    "DataScopes",
 )

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -706,7 +706,7 @@ class SystemRoles(ApiEndpointGroup):
 
     get: ApiEndpoint = ApiEndpoint(
         method="get",
-        path="api/V4.0/settings/roles",
+        path="api/settings/roles",
         request_schema_cls=None,
         request_model_cls=None,
         response_schema_cls=json_api.system_roles.SystemRoleSchema,
@@ -716,7 +716,7 @@ class SystemRoles(ApiEndpointGroup):
 
     create: ApiEndpoint = ApiEndpoint(
         method="post",
-        path="api/V4.0/settings/roles",
+        path="api/settings/roles",
         request_schema_cls=json_api.system_roles.SystemRoleCreateSchema,
         request_model_cls=json_api.system_roles.SystemRoleCreate,
         response_schema_cls=json_api.system_roles.SystemRoleSchema,
@@ -725,7 +725,7 @@ class SystemRoles(ApiEndpointGroup):
 
     delete: ApiEndpoint = ApiEndpoint(
         method="delete",
-        path="api/V4.0/settings/roles/{uuid}",
+        path="api/settings/roles/{uuid}",
         request_schema_cls=None,
         request_model_cls=json_api.resources.ResourceDelete,
         response_schema_cls=json_api.generic.MetadataSchema,
@@ -735,7 +735,7 @@ class SystemRoles(ApiEndpointGroup):
 
     update: ApiEndpoint = ApiEndpoint(
         method="put",
-        path="api/V4.0/settings/roles/{uuid}",
+        path="api/settings/roles/{uuid}",
         request_schema_cls=json_api.system_roles.SystemRoleUpdateSchema,
         request_model_cls=json_api.system_roles.SystemRoleUpdate,
         response_schema_cls=json_api.system_roles.SystemRoleSchema,
@@ -744,7 +744,7 @@ class SystemRoles(ApiEndpointGroup):
 
     perms: ApiEndpoint = ApiEndpoint(
         method="get",
-        path="api/V4.0/labels",
+        path="api/labels",
         request_schema_cls=None,
         request_model_cls=None,
         response_schema_cls=None,

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -131,6 +131,17 @@ class SavedQueries(ApiEndpointGroup):
         response_model_cls=json_api.saved_queries.SavedQuery,
     )
 
+    # WIP: folders
+    get_folders: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/V4.5/queries/folders",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.saved_queries.FoldersResponseSchema,
+        response_model_cls=json_api.saved_queries.FoldersResponse,
+    )
+    # PBUG: response not properly modeled
+
     create: ApiEndpoint = ApiEndpoint(
         method="post",
         path="api/V4.0/{asset_type}/views",
@@ -952,6 +963,47 @@ class OpenAPISpec(ApiEndpointGroup):
 
 
 @dataclasses.dataclass(repr=False)
+class DataScopes(ApiEndpointGroup):
+    """Pass."""
+
+    get: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/settings/data_scope",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.data_scopes.DataScopeDetailsSchema,
+        response_model_cls=json_api.data_scopes.DataScopeDetails,
+    )
+
+    create: ApiEndpoint = ApiEndpoint(
+        method="post",
+        path="api/settings/data_scope",
+        request_schema_cls=json_api.data_scopes.DataScopeCreateSchema,
+        request_model_cls=json_api.data_scopes.DataScopeCreate,
+        response_schema_cls=json_api.generic.MetadataSchema,
+        response_model_cls=json_api.generic.Metadata,
+    )
+
+    delete: ApiEndpoint = ApiEndpoint(
+        method="delete",
+        path="api/settings/data_scope/{uuid}",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.MetadataSchema,
+        response_model_cls=json_api.generic.Metadata,
+    )
+
+    update: ApiEndpoint = ApiEndpoint(
+        method="put",
+        path="api/settings/data_scope/{uuid}",
+        request_schema_cls=json_api.data_scopes.DataScopeUpdateSchema,
+        request_model_cls=json_api.data_scopes.DataScopeUpdate,
+        response_schema_cls=json_api.generic.MetadataSchema,
+        response_model_cls=json_api.generic.Metadata,
+    )
+
+
+@dataclasses.dataclass(repr=False)
 class ApiEndpoints(BaseData):
     """Pass."""
 
@@ -970,6 +1022,7 @@ class ApiEndpoints(BaseData):
     saved_queries: ApiEndpointGroup = SavedQueries()
     assets: ApiEndpointGroup = Assets()
     openapi: ApiEndpointGroup = OpenAPISpec()
+    data_scopes: ApiEndpointGroup = DataScopes()
 
     @classmethod
     def get_groups(cls) -> Dict[str, ApiEndpointGroup]:

--- a/axonius_api_client/api/assets/asset_mixin.py
+++ b/axonius_api_client/api/assets/asset_mixin.py
@@ -641,6 +641,15 @@ class AssetMixin(ModelMixins):
         self.LOG.debug(f"Built query: {query!r}")
         return query
 
+    @property
+    def data_scopes(self):
+        """Work with data scopes."""
+        if not hasattr(self, "_data_scopes"):
+            from ..system import DataScopes
+
+            self._data_scopes: DataScopes = DataScopes(auth=self.auth)
+        return self._data_scopes
+
     def _init(self, **kwargs):
         """Post init method for subclasses to use for extra setup."""
         from ..adapters import Adapters

--- a/axonius_api_client/api/json_api/__init__.py
+++ b/axonius_api_client/api/json_api/__init__.py
@@ -8,6 +8,7 @@ from . import (
     base,
     central_core,
     custom_fields,
+    data_scopes,
     enforcements,
     generic,
     instances,
@@ -24,6 +25,7 @@ from . import (
 )
 
 __all__ = (
+    "data_scopes",
     "base",
     "custom_fields",
     "resources",

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -122,10 +122,10 @@ class BaseSchema(BaseCommon, marshmallow.Schema):
         if not dataclasses.is_dataclass(model_cls):
             return model_cls(**data) if callable(model_cls) else data
 
-        fields_known = [x.name for x in dataclasses.fields(model_cls)]
-        extra_attributes = {k: data.pop(k) for k in list(data) if k not in fields_known}
+        # fields_known = [x.name for x in dataclasses.fields(model_cls)]
+        # extra_attributes = {k: data.pop(k) for k in list(data) if k not in fields_known}
         obj = model_cls.from_dict(data)
-        obj.extra_attributes = extra_attributes
+        # obj.extra_attributes = extra_attributes
         return obj
 
 
@@ -284,6 +284,15 @@ class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
         """Pass."""
         props = self._to_str_properties()
         return self._str_join().join(props) if props else super().__str__()
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Pass."""
+        fields_known = [x.name for x in dataclasses.fields(cls)]
+        extra_attributes = {k: data.pop(k) for k in list(data) if k not in fields_known}
+        obj = super().from_dict(data)
+        obj.extra_attributes = extra_attributes
+        return obj
 
     @staticmethod
     def _human_key(key):  # pragma: no cover
@@ -446,5 +455,5 @@ class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
     @extra_attributes.setter
     def extra_attributes(self, value: dict):
         if value:
-            LOGGER.warning(f"Extra attributes found:\n{json_dump(value)}")
+            LOGGER.warning(f"Extra attributes found in {self}:\n{json_dump(value)}")
         self._extra_attributes = value

--- a/axonius_api_client/api/json_api/data_scopes.py
+++ b/axonius_api_client/api/json_api/data_scopes.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+"""Models for API requests & responses."""
+import dataclasses
+import datetime
+from typing import ClassVar, Dict, List, Optional, Type
+
+import marshmallow
+import marshmallow_jsonapi
+
+from ...tools import json_load
+from .base import BaseModel, BaseSchema, BaseSchemaJson
+from .custom_fields import SchemaDatetime
+from .saved_queries import SavedQuery
+
+
+@dataclasses.dataclass
+class DataScope(BaseModel):
+    """Pass."""
+
+    name: str
+    uuid: str
+
+    created_at: datetime.datetime = dataclasses.field(
+        metadata={"dataclasses_json": {"mm_field": SchemaDatetime()}}
+    )
+    last_updated: datetime.datetime = dataclasses.field(
+        metadata={"dataclasses_json": {"mm_field": SchemaDatetime()}}
+    )
+
+    description: str = ""
+    updated_by: str = ""
+
+    associated_roles: List[str] = dataclasses.field(default_factory=list)
+    users_queries: List[str] = dataclasses.field(default_factory=list)
+    devices_queries: List[str] = dataclasses.field(default_factory=list)
+
+    ASSET_SCOPES: ClassVar[Dict[str, List[SavedQuery]]] = None
+
+    def __str__(self) -> str:
+        """Pass."""
+        user_scopes = [x.name for x in self.user_scopes]
+        device_scopes = [x.name for x in self.device_scopes]
+        items = [
+            f"name={self.name!r}",
+            f"uuid={self.uuid!r}",
+            f"description={self.description!r}",
+            f"associated_roles={self.associated_roles}",
+            f"user_scopes={user_scopes}",
+            f"device_scopes={device_scopes}",
+        ]
+        return "\n".join(items)
+
+    @property
+    def updated_user_obj(self) -> dict:
+        """Pass."""
+        if not hasattr(self, "_updated_user_obj"):
+            self._updated_user_obj = json_load(self.updated_by)
+        return self._updated_user_obj
+
+    @property
+    def updated_user_name(self) -> str:
+        """Get the user name of the user that last updated this set."""
+        return self.updated_user_obj.get("user_name", "")
+
+    @property
+    def updated_user_source(self) -> str:
+        """Get the source of the user that last updated this set."""
+        return self.updated_user_obj.get("source", "")
+
+    @property
+    def updated_user_first_name(self) -> str:
+        """Get the first name of the user that last updated this set."""
+        return self.updated_user_obj.get("first_name", "")
+
+    @property
+    def updated_user_last_name(self) -> str:
+        """Get the last name of the user that last updated this set."""
+        return self.updated_user_obj.get("last_name", "")
+
+    @property
+    def updated_user_full_name(self) -> str:
+        """Get the first and last name of the user that last updated this set."""
+        return " ".join(
+            [x for x in [self.updated_user_first_name, self.updated_user_last_name] if x]
+        )
+
+    @property
+    def updated_user(self) -> str:
+        """Pass."""
+        return f"{self.updated_user_source}/{self.updated_user_name}"
+
+    def to_tablize(self) -> dict:
+        """Pass."""
+        ident = [
+            f"Name: {self.name!r}",
+            f"UUID: {self.uuid!r}",
+            f"Description: {self.description!r}",
+            f"Updated Date: {self.last_updated.isoformat()!r}",
+            f"Updated User: {self.updated_user!r}",
+        ]
+        return {
+            "Identifier": "\n".join(ident),
+            "Associated Roles": "\n".join(self.associated_roles),
+            "User Asset Scopes": "\n".join([x.name for x in self.user_scopes]),
+            "Device Asset Scopes": "\n".join([x.name for x in self.device_scopes]),
+        }
+
+    @property
+    def user_scopes(self) -> List[SavedQuery]:
+        """Pass."""
+        return [x for x in self.ASSET_SCOPES["users"] if x.uuid in self.users_queries]
+
+    @property
+    def device_scopes(self) -> List[SavedQuery]:
+        """Pass."""
+        return [x for x in self.ASSET_SCOPES["devices"] if x.uuid in self.devices_queries]
+
+
+class DataScopeDetailsSchema(BaseSchemaJson):
+    """Pass."""
+
+    scopes = marshmallow_jsonapi.fields.List(
+        marshmallow_jsonapi.fields.Dict(), description="Data Scope objects"
+    )
+    settings = marshmallow_jsonapi.fields.Dict(description="Data Scopes settings")
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return DataScopeDetails
+
+    class Meta:
+        """Pass."""
+
+        type_ = "data_scope_details_schema"
+
+
+@dataclasses.dataclass
+class DataScopeDetails(BaseModel):
+    """Pass."""
+
+    scopes: List[dict]
+    settings: dict
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return DataScopeDetailsSchema
+
+    def get_scopes(self, asset_scopes: Dict[str, List[SavedQuery]]) -> List[DataScope]:
+        """Pass."""
+        schema = DataScope.schema(many=True)
+        objs = schema.load(self.scopes, unknown=marshmallow.INCLUDE)
+        for obj in objs:
+            obj.HTTP = self.HTTP
+            obj.ASSET_SCOPES = asset_scopes
+        return objs
+
+
+class DataScopeCreateSchema(BaseSchemaJson):
+    """Pass."""
+
+    name = marshmallow_jsonapi.fields.Str(description="Name of Data Scope")
+    description = marshmallow_jsonapi.fields.Str(
+        description="Description of Data Scope",
+        load_default="",
+        dump_default="",
+        allow_none=True,
+    )
+    devices_queries = marshmallow_jsonapi.fields.List(
+        marshmallow_jsonapi.fields.Str(),
+        description="Asset Scope UUIDs for type 'devices'",
+    )
+    users_queries = marshmallow_jsonapi.fields.List(
+        marshmallow_jsonapi.fields.Str(),
+        description="Asset Scope UUIDs for type 'users'",
+    )
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return DataScopeCreate
+
+    class Meta:
+        """Pass."""
+
+        type_ = "data_scope_request_schema"
+
+
+@dataclasses.dataclass
+class DataScopeCreate(BaseModel):
+    """Pass."""
+
+    name: str
+    devices_queries: List[str] = dataclasses.field(default_factory=list)
+    users_queries: List[str] = dataclasses.field(default_factory=list)
+    description: str = ""
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return DataScopeCreateSchema
+
+
+class DataScopeUpdateSchema(BaseSchemaJson):
+    """Pass."""
+
+    uuid = marshmallow_jsonapi.fields.Str(description="UUID of Data Scope")
+    name = marshmallow_jsonapi.fields.Str(description="Name of Data Scope")
+    description = marshmallow_jsonapi.fields.Str(
+        description="Description of Data Scope",
+        load_default="",
+        dump_default="",
+        allow_none=True,
+    )
+    devices_queries = marshmallow_jsonapi.fields.List(
+        marshmallow_jsonapi.fields.Str(),
+        description="Asset Scope UUIDs for type 'devices'",
+    )
+    users_queries = marshmallow_jsonapi.fields.List(
+        marshmallow_jsonapi.fields.Str(),
+        description="Asset Scope UUIDs for type 'users'",
+    )
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return DataScopeUpdate
+
+    class Meta:
+        """Pass."""
+
+        type_ = "data_scope_request_schema"
+
+
+@dataclasses.dataclass
+class DataScopeUpdate(BaseModel):
+    """Pass."""
+
+    uuid: str
+    name: str
+    devices_queries: List[str] = dataclasses.field(default_factory=list)
+    users_queries: List[str] = dataclasses.field(default_factory=list)
+    description: str = ""
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return DataScopeUpdateSchema

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -3,12 +3,13 @@
 import dataclasses
 import datetime
 import textwrap
-from typing import List, Optional, Type
+from typing import ClassVar, List, Optional, Type, Union
 
+import marshmallow
 import marshmallow_jsonapi
 
 from ...constants.api import GUI_PAGE_SIZES
-from ...exceptions import ApiAttributeTypeError
+from ...exceptions import ApiAttributeTypeError, ApiError
 from ...tools import coerce_bool, coerce_int, listify
 from .base import BaseModel, BaseSchema, BaseSchemaJson
 from .custom_fields import SchemaBool, SchemaDatetime
@@ -42,6 +43,10 @@ class SavedQuerySchema(BaseSchemaJson):
     )
     user_id = marshmallow_jsonapi.fields.Str(allow_none=True, load_default=None, dump_default=None)
     uuid = marshmallow_jsonapi.fields.Str(allow_none=True, load_default=None, dump_default=None)
+    # WIP: folders
+    # folder_id = marshmallow_jsonapi.fields.Str(
+    #     allow_none=True, load_default=None, dump_default=None
+    # )
 
     @staticmethod
     def get_model_cls() -> type:
@@ -68,6 +73,22 @@ class SavedQueryDeleteSchema(PrivateRequestSchema):
         type_ = "delete_view_schema"
 
 
+class FoldersResponseSchema(BaseSchemaJson):
+    """Pass."""
+
+    folders = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Dict())
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return FoldersResponse
+
+    class Meta:
+        """Pass."""
+
+        type_ = "queries_folders_response_schema"
+
+
 class SavedQueryCreateSchema(BaseSchemaJson):
     """Pass."""
 
@@ -78,6 +99,10 @@ class SavedQueryCreateSchema(BaseSchemaJson):
     private = SchemaBool(load_default=False, dump_default=False)
     tags = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
     asset_scope = SchemaBool(load_default=False, dump_default=False)
+    # WIP: folders
+    # folder_id = marshmallow_jsonapi.fields.Str(
+    #     allow_none=True, load_default=None, dump_default=None
+    # )
 
     @staticmethod
     def get_model_cls() -> type:
@@ -253,7 +278,6 @@ class SavedQuery(BaseModel, SavedQueryMixins):
     last_updated: Optional[datetime.datetime] = dataclasses.field(
         default=None,
         metadata={
-            "update": False,
             "dataclasses_json": {"mm_field": SchemaDatetime(allow_none=True)},
         },
     )
@@ -265,6 +289,8 @@ class SavedQuery(BaseModel, SavedQueryMixins):
     predefined: bool = dataclasses.field(default=False, metadata={"update": False})
     is_asset_scope_query_ready: bool = dataclasses.field(default=False, metadata={"update": False})
     is_referenced: bool = dataclasses.field(default=False, metadata={"update": False})
+    # WIP: folders
+    # folder_id: Optional[str] = None
     document_meta: Optional[dict] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -345,6 +371,8 @@ class SavedQueryCreate(BaseModel, SavedQueryMixins):
     asset_scope: bool = dataclasses.field(default=False)
     private: bool = dataclasses.field(default=False)
     tags: List[str] = dataclasses.field(default_factory=list)
+    # WIP: folders
+    # folder_id: Optional[str] = None
 
     @staticmethod
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
@@ -360,3 +388,157 @@ class SavedQueryDelete(PrivateRequest):
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
         return SavedQueryDeleteSchema
+
+
+# WIP: folders
+FOLDER_SEP: str = "//"
+
+
+# WIP: folders
+@dataclasses.dataclass
+class Folder(BaseModel):
+    """Pass."""
+
+    _id: str
+    children_ids: List[str]
+    depth: int
+    name: str
+    root_type: str
+    created_at: datetime.datetime = dataclasses.field(
+        metadata={"dataclasses_json": {"mm_field": SchemaDatetime()}}
+    )
+    updated_at: datetime.datetime = dataclasses.field(
+        metadata={"dataclasses_json": {"mm_field": SchemaDatetime()}}
+    )
+    path: List[str]
+    children: Optional[List[dict]] = dataclasses.field(default_factory=list)
+    root_id: Optional[str] = None
+    created_by: Optional[str] = None
+    parent_id: Optional[str] = None
+    read_only: bool = False
+
+    PARENT: ClassVar[Optional[Union["Folder", "FoldersResponse"]]] = None
+
+    @property
+    def id(self) -> str:
+        """Pass."""
+        return self._id
+
+    @property
+    def path_str(self) -> str:
+        """Pass."""
+        return f" {FOLDER_SEP} ".join(self.path)
+
+    @property
+    def children_count(self) -> int:
+        """Pass."""
+        return len(self.children_ids)
+
+    @property
+    def models(self) -> List["Folder"]:
+        """Pass."""
+        schema = self.schema(many=True)
+        items = schema.load(self.children, unknown=marshmallow.INCLUDE)
+        for item in items:
+            item.HTTP = self.HTTP
+            item.PARENT = self
+        return items
+
+    def find_folder(self, value: str) -> "Folder":
+        """Pass."""
+        err = f"No folder named {value!r} found under {self.path_str!r}"
+        if not self.children:
+            raise ApiError(f"{err}No folders exist under {self.path_str!r}")
+
+        for model in self.models:
+            if model.name == value:
+                return model
+
+        valids = "\n" + "\n".join([str(x) for x in self.models])
+        raise ApiError(f"{err}, valids:{valids}")
+
+    def __str__(self) -> str:
+        """Pass."""
+        children = [x.name for x in self.models]
+        items = [
+            f"id: {self.id!r}",
+            f"name: {self.name!r}",
+            f"path: {self.path_str!r}",
+            f"children: {children}",
+        ]
+        items = ", ".join(items)
+        return f"Folder({items})"
+
+    def __repr__(self) -> str:
+        """Pass."""
+        return self.__str__()
+
+
+# WIP: folders
+@dataclasses.dataclass
+class FoldersResponse(BaseModel):
+    """Pass."""
+
+    folders: List[dict]
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return FoldersResponseSchema
+
+    @property
+    def models(self) -> List[Folder]:
+        """Pass."""
+        schema = Folder.schema(many=True)
+        items = schema.load(self.folders, unknown=marshmallow.INCLUDE)
+        for item in items:
+            item.HTTP = self.HTTP
+            item.PARENT = self
+        return items
+
+    def find_folder(self, value: str) -> "Folder":
+        """Pass."""
+        for model in self.models:
+            if model.name == value:
+                return model
+
+        valids = "\n" + "\n".join([str(x) for x in self.models])
+        raise ApiError(f"No root folder named {value!r} found, valids:{valids}")
+
+    def search(self, value: Union[str, List[str]]) -> Folder:
+        """Find a folder by path."""
+        if isinstance(value, str):
+            value = [x.strip() for x in value.split(FOLDER_SEP) if x.strip()]
+
+        if not isinstance(value, list) and value and all([isinstance(x, str) and x for x in value]):
+            msg = (
+                f"Invalid folder search value {value!r} ({type(value)})\n"
+                f"Folder search value must be a list of str or a str separated by {FOLDER_SEP!r}"
+            )
+            raise ApiError(msg)
+
+        folder = None
+        for item in value:
+            folder = folder.find_folder(value=item) if folder else self.find_folder(value=item)
+        return folder
+
+    def get_tree(self, models: Optional[List["Folder"]] = None):
+        """Pass."""
+        models = self.models if models is None else models
+
+        items = []
+        for model in models:
+            items.append(f"{model.path_str}")
+            items += self.get_tree(models=model.models)
+        return items
+
+    def __str__(self) -> str:
+        """Pass."""
+        items = ",\n".join(
+            [f"Folder(name={x.name!r}, children={[y.name for y in x.models]})" for x in self.models]
+        )
+        return items
+
+    def __repr__(self) -> str:
+        """Pass."""
+        return self.__str__()

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -396,7 +396,7 @@ FOLDER_SEP: str = "//"
 
 # WIP: folders
 @dataclasses.dataclass
-class Folder(BaseModel):
+class Folder(BaseModel):  # pragma: no cover
     """Pass."""
 
     _id: str
@@ -476,7 +476,7 @@ class Folder(BaseModel):
 
 # WIP: folders
 @dataclasses.dataclass
-class FoldersResponse(BaseModel):
+class FoldersResponse(BaseModel):  # pragma: no cover
     """Pass."""
 
     folders: List[dict]

--- a/axonius_api_client/api/json_api/system_settings.py
+++ b/axonius_api_client/api/json_api/system_settings.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Type
 import dataclasses_json
 import marshmallow_jsonapi
 
+from ...exceptions import FeatureNotEnabledError
 from ...tools import dt_days_left, dt_parse
 from .base import BaseModel, BaseSchema, BaseSchemaJson
 from .custom_fields import SchemaDatetime, get_field_dc_mm
@@ -108,18 +109,27 @@ class FeatureFlags(SystemSettings):
         """Get the status of cloud compliance module being enabled."""
         return self._cloud_compliance.get("enabled", False)
 
-    @property
-    def asset_scopes_enabled(self) -> bool:
-        """Get the status of asset scopes being enabled."""
-        return self._asset_scope.get("enabled", False)
+    def data_scope_check(self):
+        """Check if data scope feature flag is enabled.
+
+        Raises:
+            FeatureNotEnabledError: if data scope feature flag is not enabled
+        """
+        if not self.data_scopes_enabled:
+            raise FeatureNotEnabledError(name="Data Scopes")
 
     @property
-    def asset_scopes_max(self) -> Optional[int]:
-        """Get the max number of asset scopes allowed."""
-        return self._asset_scope.get("queries_limit", None)
+    def data_scopes_enabled(self) -> bool:
+        """Get the status of data scopes being enabled."""
+        return self._data_scopes.get("enabled", False)
 
     @property
-    def _asset_scope(self) -> dict:
+    def data_scopes_max(self) -> Optional[int]:
+        """Get the max number of data scopes allowed."""
+        return self._data_scopes.get("queries_limit", None)
+
+    @property
+    def _data_scopes(self) -> dict:
         return self.config.get("data_scope") or {}
 
     @property

--- a/axonius_api_client/api/system/__init__.py
+++ b/axonius_api_client/api/system/__init__.py
@@ -2,13 +2,10 @@
 """APIs for working with system components."""
 from .activity_logs import ActivityLogs
 from .dashboard import Dashboard
+from .data_scopes import DataScopes
 from .instances import Instances
 from .meta import Meta
 from .remote_support import RemoteSupport
-
-# from .settings_global import SettingsGlobal
-# from .settings_gui import SettingsGui
-# from .settings_identity_providers import SettingsIdentityProviders
 from .settings import SettingsGlobal, SettingsGui, SettingsIdentityProviders, SettingsLifecycle
 from .signup import Signup
 from .system_roles import SystemRoles
@@ -27,4 +24,5 @@ __all__ = (
     "RemoteSupport",
     "ActivityLogs",
     "SettingsIdentityProviders",
+    "DataScopes",
 )

--- a/axonius_api_client/api/system/data_scopes.py
+++ b/axonius_api_client/api/system/data_scopes.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""API for working with data scopes."""
+from typing import Dict, List, Optional, Union
+
+from ...exceptions import ApiError, NotFoundError
+from ...parsers.tables import tablize
+from ...tools import listify
+from .. import json_api
+from ..api_endpoints import ApiEndpoints
+from ..mixins import ModelMixins
+
+MODEL = json_api.data_scopes.DataScope
+
+
+class DataScopes(ModelMixins):
+    """API for working with Data Scopes."""
+
+    def get(self, value: Optional[str] = None) -> Union[MODEL, List[MODEL]]:
+        """Pass."""
+        self.check_enabled()
+        asset_scopes = self.get_asset_scopes()
+        response = self._get()
+        scopes = response.get_scopes(asset_scopes=asset_scopes)
+
+        if value is not None:
+            for scope in scopes:
+                if value in [scope.name, scope.uuid]:
+                    return scope
+
+            raise NotFoundError(
+                tablize(
+                    value=[x.to_tablize() for x in scopes],
+                    err=f"Data scope with name or UUID of {value!r} not found",
+                )
+            )
+        return scopes
+
+    def create(
+        self,
+        name: str,
+        device_scopes: Optional[List[str]] = None,
+        user_scopes: Optional[List[str]] = None,
+        description: str = "",
+    ):
+        """Pass."""
+        if not any([device_scopes, user_scopes]):
+            raise ApiError("Must supply at least one user or device scope")
+
+        self.check_exists(value=name)
+
+        devices_queries = [
+            self.devices.saved_query.get_by_multi(x, as_dataclass=True, asset_scopes=True).uuid
+            for x in listify(device_scopes)
+        ]
+        users_queries = [
+            self.users.saved_query.get_by_multi(x, as_dataclass=True, asset_scopes=True).uuid
+            for x in listify(user_scopes)
+        ]
+        self._create(
+            name=name,
+            devices_queries=devices_queries,
+            users_queries=users_queries,
+            description=description,
+        )
+        return self.get(value=name)
+
+    def delete(self, value: str) -> MODEL:
+        """Pass."""
+        item = self.get(value=value)
+        self._delete(uuid=item.uuid)
+        return item
+
+    def update_name(self, value: str, update: str) -> MODEL:
+        """Pass."""
+        item = self.get(value=value)
+        self.check_exists(value=update)
+        item.name = update
+        self._update_from_model(value=item)
+        return self.get(value=update)
+
+    def update_description(self, value: str, update: str) -> MODEL:
+        """Pass."""
+        item = self.get(value=value)
+        item.description = update
+        self._update_from_model(value=item)
+        return self.get(value=value)
+
+    def update_user_scopes(
+        self, value: str, update: List[str], append: bool = False, remove: bool = False
+    ) -> MODEL:
+        """Pass."""
+        item = self.get(value=value)
+        queries = [
+            self.users.saved_query.get_by_multi(x, as_dataclass=True, asset_scopes=True)
+            for x in listify(update)
+        ]
+        query_ids = [x.uuid for x in queries]
+
+        if not queries:
+            raise ApiError("Must supply at least one user asset scope")
+
+        if remove:
+            item.users_queries = [x for x in item.users_queries if x not in query_ids]
+        elif append:
+            item.users_queries += [x for x in query_ids if x not in item.users_queries]
+        else:
+            item.users_queries = query_ids
+
+        self._update_from_model(value=item)
+        return self.get(value=value)
+
+    def update_device_scopes(
+        self, value: str, update: List[str], append: bool = False, remove: bool = False
+    ) -> MODEL:
+        """Pass."""
+        item = self.get(value=value)
+        queries = [
+            self.devices.saved_query.get_by_multi(x, as_dataclass=True, asset_scopes=True)
+            for x in listify(update)
+        ]
+        query_ids = [x.uuid for x in queries]
+
+        if not queries:
+            raise ApiError("Must supply at least one device asset scope")
+
+        if remove:
+            item.devices_queries = [x for x in item.devices_queries if x not in query_ids]
+        elif append:
+            item.devices_queries += [x for x in query_ids if x not in item.devices_queries]
+        else:
+            item.devices_queries = query_ids
+
+        self._update_from_model(value=item)
+        return self.get(value=value)
+
+    def check_enabled(self):
+        """Pass."""
+        self.instances.feature_flags.data_scope_check()
+
+    def check_exists(self, value: str):
+        """Pass."""
+        try:
+            existing = self.get(value=value)
+        except NotFoundError:
+            return
+        else:
+            raise ApiError(f"Data scope with name of {value!r} already exists:\n{existing}")
+
+    def get_asset_scopes(self) -> Dict[str, List[json_api.saved_queries.SavedQuery]]:
+        """Pass."""
+        return {
+            "devices": [
+                x for x in self.devices.saved_query.get(as_dataclass=True) if x.asset_scope
+            ],
+            "users": [x for x in self.users.saved_query.get(as_dataclass=True) if x.asset_scope],
+        }
+
+    def _init(self, **kwargs):
+        """Post init method for subclasses to use for extra setup."""
+        from .. import Devices, Users, Instances
+
+        self.devices: Devices = Devices(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+        self.users: Users = Users(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+        self.instances: Instances = Instances(auth=self.auth, **kwargs)
+        """API model for cross reference."""
+
+    def _get(self) -> json_api.data_scopes.DataScopeDetails:
+        """Direct API method to get all data scopes."""
+        api_endpoint = ApiEndpoints.data_scopes.get
+        return api_endpoint.perform_request(http=self.auth.http)
+
+    def _delete(self, uuid: str) -> json_api.generic.Metadata:
+        """Pass."""
+        api_endpoint = ApiEndpoints.data_scopes.delete
+        return api_endpoint.perform_request(http=self.auth.http, uuid=uuid)
+
+    def _create(
+        self, name: str, devices_queries: List[str], users_queries: List[str], description: str = ""
+    ) -> json_api.generic.Metadata:
+        """Direct API method to create a data scope."""
+        api_endpoint = ApiEndpoints.data_scopes.create
+        request_obj = api_endpoint.load_request(
+            name=name,
+            devices_queries=devices_queries,
+            users_queries=users_queries,
+            description=description,
+        )
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
+
+    def _update(
+        self,
+        uuid: str,
+        name: str,
+        devices_queries: List[str],
+        users_queries: List[str],
+        description: str = "",
+    ) -> json_api.generic.Metadata:
+        """Direct API method to update a data scope."""
+        api_endpoint = ApiEndpoints.data_scopes.update
+        request_obj = api_endpoint.load_request(
+            uuid=uuid,
+            name=name,
+            devices_queries=devices_queries,
+            users_queries=users_queries,
+            description=description,
+        )
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj, uuid=uuid)
+
+    def _update_from_model(self, value: MODEL) -> json_api.generic.Metadata:
+        """Pass."""
+        return self._update(
+            uuid=value.uuid,
+            name=value.name,
+            devices_queries=value.devices_queries,
+            users_queries=value.users_queries,
+            description=value.description,
+        )

--- a/axonius_api_client/cli/grp_assets/grp_saved_query/grp_common.py
+++ b/axonius_api_client/cli/grp_assets/grp_saved_query/grp_common.py
@@ -57,7 +57,7 @@ OPT_EXPORT = click.option(
     "-xf",
     "export_format",
     type=click.Choice(list(EXPORT_FORMATS)),
-    help="Format of to export data in",
+    help="Format to export data in",
     default="table",
     show_envvar=True,
     show_default=True,

--- a/axonius_api_client/cli/grp_system/__init__.py
+++ b/axonius_api_client/cli/grp_system/__init__.py
@@ -6,6 +6,7 @@ from ..context import AliasedGroup
 from . import (
     grp_activity_logs,
     grp_central_core,
+    grp_data_scopes,
     grp_discover,
     grp_meta,
     grp_nodes,
@@ -32,3 +33,4 @@ system.add_command(grp_users.users)
 system.add_command(grp_discover.discover)
 system.add_command(grp_remote_support.remote_support)
 system.add_command(grp_activity_logs.activity_logs)
+system.add_command(grp_data_scopes.data_scopes)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/__init__.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+import click
+
+from ...context import AliasedGroup, load_cmds
+
+
+@click.group(cls=AliasedGroup)
+def data_scopes():
+    """Group: Manage Data Scopes."""
+
+
+load_cmds(path=__file__, package=__package__, group=data_scopes)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_create.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_create.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPTS_EXPORT
+
+OPT_NAME = click.option(
+    "--name",
+    "-n",
+    "name",
+    help="Name of data scope",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_DESCRIPTION = click.option(
+    "--description",
+    "-d",
+    "description",
+    default="",
+    help="Description of data scope",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_DEVICE_SCOPES = click.option(
+    "--device-scope",
+    "-ds",
+    "device_scopes",
+    help="Name or UUID of a Device Asset Scope (multiple)",
+    multiple=True,
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_USER_SCOPES = click.option(
+    "--user-scope",
+    "-us",
+    "user_scopes",
+    help="Name or UUID of a User Asset Scope (multiple)",
+    multiple=True,
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_NAME, OPT_DESCRIPTION, OPT_DEVICE_SCOPES, OPT_USER_SCOPES]
+
+
+@click.command(name="create", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(
+    ctx,
+    url,
+    key,
+    secret,
+    export_format,
+    table_format,
+    name,
+    description,
+    device_scopes,
+    user_scopes,
+):
+    """Create a data scope."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.data_scopes.create(
+            name=name, description=description, device_scopes=device_scopes, user_scopes=user_scopes
+        )
+
+    ctx.obj.echo_ok(f"Successfully created data scope: {data.name}")
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_delete.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_delete.py
@@ -2,21 +2,21 @@
 """Command line interface for Axonius API Client."""
 from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
-from .grp_common import EXPORT_FORMATS, OPT_ROLE_NAME, OPTS_EXPORT
+from .grp_common import EXPORT_FORMATS, OPT_VALUE, OPTS_EXPORT
 
-OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME]
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE]
 
 
 @click.command(name="delete", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, name, export_format, table_format, **kwargs):
-    """Delete a role."""
+def cmd(ctx, url, key, secret, export_format, table_format, value):
+    """Delete a data scope."""
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        data = client.system_roles.delete_by_name(name=name)
-        ctx.obj.echo_ok(f"Deleted role {name!r}")
+        data = client.data_scopes.delete(value=value)
 
+    ctx.obj.echo_ok(f"Successfully deleted data scope: {data.name}")
     click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_get.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_get.py
@@ -4,18 +4,30 @@ from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
 from .grp_common import EXPORT_FORMATS, OPTS_EXPORT
 
-OPTIONS = [*AUTH, *OPTS_EXPORT]
+OPT_VALUE = click.option(
+    "--value",
+    "-v",
+    "value",
+    help="Name or UUID of data scope",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE]
 
 
 @click.command(name="get", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, export_format, table_format, **kwargs):
-    """Get all roles."""
+def cmd(ctx, url, key, secret, export_format, table_format, value):
+    """Get data scopes."""
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        data = client.system_roles.get()
+        data = client.data_scopes.get(value=value)
 
+    count = len(data) if isinstance(data, list) else 1
+    ctx.obj.echo_ok(f"Fetched {count} data scopes")
     click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_description.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_description.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_VALUE, OPTS_EXPORT
+
+OPT_UPDATE = click.option(
+    "--update",
+    "-up",
+    "update",
+    help="New description",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE, OPT_UPDATE]
+
+
+@click.command(name="update-description", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, table_format, value, update):
+    """Update the description of a data scope."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.data_scopes.update_description(value=value, update=update)
+
+    ctx.obj.echo_ok(f"Successfully updated data scope: {data.name}")
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_device_scopes.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_device_scopes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_VALUE, OPTS_EXPORT, OPTS_UPDATE_SCOPE
+
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE, *OPTS_UPDATE_SCOPE]
+
+
+@click.command(name="update-device-scopes", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, table_format, value, update, append, remove):
+    """Update the device asset scopes of a data scope."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.data_scopes.update_device_scopes(
+            value=value, update=update, append=append, remove=remove
+        )
+
+    ctx.obj.echo_ok(f"Successfully updated data scope: {data.name}")
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_name.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_name.py
@@ -2,31 +2,31 @@
 """Command line interface for Axonius API Client."""
 from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
-from .grp_common import EXPORT_FORMATS, OPT_ROLE_NAME, OPTS_EXPORT
+from .grp_common import EXPORT_FORMATS, OPT_VALUE, OPTS_EXPORT
 
 OPT_UPDATE = click.option(
-    "--new-name",
-    "-nn",
-    "new_name",
-    help="New name of role",
+    "--update",
+    "-up",
+    "update",
+    help="New name",
     required=True,
     show_envvar=True,
     show_default=True,
 )
 
-OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME, OPT_UPDATE]
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE, OPT_UPDATE]
 
 
 @click.command(name="update-name", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, export_format, table_format, name, new_name, **kwargs):
-    """Update a roles name."""
+def cmd(ctx, url, key, secret, export_format, table_format, value, update):
+    """Update the name of a data scope."""
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        data = client.system_roles.set_name(name=name, new_name=new_name)
-        ctx.obj.echo_ok(f"Updated role name from {name!r} to {new_name!r}")
+        data = client.data_scopes.update_name(value=value, update=update)
 
+    ctx.obj.echo_ok(f"Successfully updated data scope: {data.name}")
     click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_user_scopes.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/cmd_update_user_scopes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_VALUE, OPTS_EXPORT, OPTS_UPDATE_SCOPE
+
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_VALUE, *OPTS_UPDATE_SCOPE]
+
+
+@click.command(name="update-user-scopes", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, table_format, value, update, append, remove):
+    """Update the user asset scopes of a data scope."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.data_scopes.update_user_scopes(
+            value=value, update=update, append=append, remove=remove
+        )
+
+    ctx.obj.echo_ok(f"Successfully updated data scope: {data.name}")
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_data_scopes/grp_common.py
+++ b/axonius_api_client/cli/grp_system/grp_data_scopes/grp_common.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ....constants.api import TABLE_FORMAT
+from ....parsers.tables import tablize
+from ....tools import json_dump, listify
+from ...context import click
+from ...options import TABLE_FMT
+
+
+def export_str(data, **kwargs):
+    """Pass."""
+    return "\n\n".join(str(x) for x in listify(data))
+
+
+def export_table(data, table_format=TABLE_FORMAT, **kwargs):
+    """Pass."""
+    return tablize(value=[x.to_tablize() for x in listify(data)], fmt=table_format)
+
+
+def export_json(data, **kwargs):
+    """Pass."""
+    return json_dump([x.to_dict() for x in data] if isinstance(data, list) else data.to_dict())
+
+
+EXPORT_FORMATS: dict = {
+    "json": export_json,
+    "str": export_str,
+    "table": export_table,
+}
+
+OPT_EXPORT = click.option(
+    "--export-format",
+    "-xf",
+    "export_format",
+    type=click.Choice(list(EXPORT_FORMATS)),
+    help="Format to export data in",
+    default="table",
+    show_envvar=True,
+    show_default=True,
+)
+
+OPTS_EXPORT = [OPT_EXPORT, TABLE_FMT]
+
+OPT_VALUE = click.option(
+    "--value",
+    "-v",
+    "value",
+    help="Name or UUID of data scope",
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_UPDATE = click.option(
+    "--update",
+    "-up",
+    "update",
+    help="Name or UUID of Asset Scope (multiple)",
+    multiple=True,
+    required=True,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_APPEND = click.option(
+    "--append/--no-append",
+    "-a/-na",
+    "append",
+    required=False,
+    default=False,
+    help="Append supplied asset scopes instead of overwriting",
+    show_envvar=True,
+    show_default=True,
+)
+OPT_REMOVE = click.option(
+    "--remove/--no-remove",
+    "-r/-nr",
+    "remove",
+    required=False,
+    default=False,
+    help="Remove supplied asset scopes instead of overwriting or appending",
+    show_envvar=True,
+    show_default=True,
+)
+OPTS_UPDATE_SCOPE = [OPT_UPDATE, OPT_APPEND, OPT_REMOVE]

--- a/axonius_api_client/cli/grp_system/grp_roles/cmd_add.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/cmd_add.py
@@ -2,20 +2,21 @@
 """Command line interface for Axonius API Client."""
 from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
-from .grp_common import EXPORT, PERMS, ROLE_NAME, handle_export
+from .grp_common import EXPORT_FORMATS, OPT_DATA_SCOPE, OPT_PERMS, OPT_ROLE_NAME, OPTS_EXPORT
 
-OPTIONS = [*AUTH, EXPORT, ROLE_NAME, PERMS]
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME, OPT_PERMS, OPT_DATA_SCOPE]
 
 
 @click.command(name="add", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, export_format, name, perms, **kwargs):
+def cmd(ctx, url, key, secret, export_format, name, perms, data_scope, table_format, **kwargs):
     """Add a role."""
     perms = dict(perms)
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        data = client.system_roles.add(name=name, **perms)
+        data = client.system_roles.add(name=name, data_scope=data_scope, **perms)
         ctx.obj.echo_ok(f"Added role {name!r}")
 
-    handle_export(ctx=ctx, data=data, export_format=export_format, **kwargs)
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_roles/cmd_get_by_name.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/cmd_get_by_name.py
@@ -2,23 +2,20 @@
 """Command line interface for Axonius API Client."""
 from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
-from .grp_common import EXPORT, ROLE_NAME, handle_export
+from .grp_common import EXPORT_FORMATS, OPT_ROLE_NAME, OPTS_EXPORT
 
-OPTIONS = [
-    *AUTH,
-    EXPORT,
-    ROLE_NAME,
-]
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME]
 
 
 @click.command(name="get-by-name", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, name, **kwargs):
+def cmd(ctx, url, key, secret, name, export_format, table_format, **kwargs):
     """Get a single role."""
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
 
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
         data = client.system_roles.get_by_name(name=name)
 
-    handle_export(ctx=ctx, data=data, **kwargs)
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_roles/cmd_get_perms.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/cmd_get_perms.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+
+OPTIONS = [*AUTH]
+
+
+@click.command(name="get-perms", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret):
+    """Get the permission categories and actions."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.system_roles.cat_actions
+
+    cats = data["categories"]
+    cat_actions = data["actions"]
+
+    for cat, actions in cat_actions.items():
+        cat_desc = cats[cat]
+        click.secho(f"Category Description: {cat_desc!r}, Name: {cat!r}")
+        for action, action_desc in actions.items():
+            click.secho(f"  Action Description: {action_desc}, Name: {action!r}")

--- a/axonius_api_client/cli/grp_system/grp_roles/cmd_update_data_scope.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/cmd_update_data_scope.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+from ...context import CONTEXT_SETTINGS, click
+from ...options import AUTH, add_options
+from .grp_common import EXPORT_FORMATS, OPT_ROLE_NAME, OPTS_EXPORT
+
+OPT_DATA_SCOPE = click.option(
+    "--data-scope",
+    "-ds",
+    "data_scope",
+    help="Name or UUID of Data Scope restriction to apply",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
+OPT_REMOVE = click.option(
+    "--remove/--no-remove",
+    "-r/-nr",
+    "remove",
+    help="Remove the data scope from the role (--data-scope value ignored)",
+    required=False,
+    default=False,
+    show_envvar=True,
+    show_default=True,
+)
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME, OPT_DATA_SCOPE, OPT_REMOVE]
+
+
+@click.command(name="update-data-scope", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, table_format, name, data_scope, remove, **kwargs):
+    """Update a roles data scope."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.system_roles.update_data_scope(
+            name=name, data_scope=data_scope, remove=remove
+        )
+        data_scope = data["data_scope_name"]
+        ctx.obj.echo_ok(f"Updated role {name!r} data scope to {data_scope!r}")
+
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_roles/cmd_update_perms.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/cmd_update_perms.py
@@ -2,9 +2,9 @@
 """Command line interface for Axonius API Client."""
 from ...context import CONTEXT_SETTINGS, click
 from ...options import AUTH, add_options
-from .grp_common import EXPORT, PERMS, ROLE_NAME, handle_export
+from .grp_common import EXPORT_FORMATS, OPT_PERMS, OPT_ROLE_NAME, OPTS_EXPORT
 
-GRANT = click.option(
+OPT_GRANT = click.option(
     "--allow/--deny",
     "-a/-d",
     "grant",
@@ -16,19 +16,13 @@ GRANT = click.option(
 )
 
 
-OPTIONS = [
-    *AUTH,
-    EXPORT,
-    ROLE_NAME,
-    PERMS,
-    GRANT,
-]
+OPTIONS = [*AUTH, *OPTS_EXPORT, OPT_ROLE_NAME, OPT_PERMS, OPT_GRANT]
 
 
 @click.command(name="update-perms", context_settings=CONTEXT_SETTINGS)
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, key, secret, export_format, name, grant, perms, **kwargs):
+def cmd(ctx, url, key, secret, export_format, table_format, name, grant, perms, **kwargs):
     """Update a roles permissions."""
     perms = dict(perms)
     client = ctx.obj.start_client(url=url, key=key, secret=secret)
@@ -36,4 +30,5 @@ def cmd(ctx, url, key, secret, export_format, name, grant, perms, **kwargs):
         data = client.system_roles.set_perms(name=name, grant=grant, **perms)
         ctx.obj.echo_ok(f"Updated role permissions for {name!r}")
 
-    handle_export(ctx=ctx, data=data, export_format=export_format, **kwargs)
+    click.secho(EXPORT_FORMATS[export_format](data=data, table_format=table_format))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_system/grp_roles/grp_common.py
+++ b/axonius_api_client/cli/grp_system/grp_roles/grp_common.py
@@ -1,22 +1,110 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-import tabulate
-
+from ....constants.api import TABLE_FORMAT
+from ....parsers.tables import tablize_roles
 from ....tools import json_dump, listify
 from ...context import SplitEquals, click
+from ...options import TABLE_FMT
 
-EXPORT = click.option(
+
+def getstr_grants(perms):
+    """Pass."""
+    grants = []
+
+    for category, actions in perms.items():
+        if all([v is True for k, v in actions.items()]):
+            allows = "all"
+        elif all([v is False for k, v in actions.items()]):
+            allows = "none"
+        else:
+            allows = [k for k, v in actions.items() if v]
+            allows = ",".join(allows)
+        grants.append(f"{category}={allows!r}")
+
+    return grants
+
+
+def export_str_args(data, **kwargs):
+    """Pass."""
+
+    def getstr(obj):
+        name = obj["name"]
+        perms = obj["permissions_flat"]
+        dsr = obj.get("data_scope_restriction")
+        dsr_name = obj.get("data_scope_name")
+
+        dsr_enabled = dsr.get("enabled", False)
+        dsr_uuid = dsr.get("data_scope")
+        dsr_show = dsr_name or dsr_uuid
+
+        items = [
+            f"--name {name!r}",
+        ]
+        items += [f"--perm {x}" for x in getstr_grants(perms)]
+        if dsr_enabled and dsr_show:
+            items.append(f"--data-scope {dsr_show!r}")
+
+        return " ".join(items)
+
+    return "\n".join(getstr(x) for x in listify(data))
+
+
+def export_str(data, **kwargs):
+    """Pass."""
+
+    def getstr(obj):
+        name = obj["name"]
+        uuid = obj["uuid"]
+        perms = obj["permissions_flat"]
+        dsr = obj.get("data_scope_restriction")
+        dsr_name = obj.get("data_scope_name")
+
+        dsr_enabled = dsr.get("enabled", False)
+        dsr_uuid = dsr.get("data_scope")
+        dsr_show = dsr_name or dsr_uuid
+        items = [
+            "-----------------------------------------------",
+            f"Name: {name}",
+            f"UUID: {uuid}",
+            f"Data Scope Enabled: {dsr_enabled}",
+            f"Data Scope: {dsr_show!r}",
+        ]
+        items += [f"Permission Category {x}" for x in getstr_grants(perms)]
+
+        return "\n".join(items)
+
+    return "\n".join(getstr(x) for x in listify(data))
+
+
+def export_table(data, table_format=TABLE_FORMAT, **kwargs):
+    """Pass."""
+    return tablize_roles(roles=listify(data), err="", fmt=table_format)
+
+
+def export_json(data, **kwargs):
+    """Pass."""
+    return json_dump(data)
+
+
+EXPORT_FORMATS: dict = {
+    "json": export_json,
+    "str": export_str,
+    "str-args": export_str_args,
+    "table": export_table,
+}
+
+OPT_EXPORT = click.option(
     "--export-format",
     "-xf",
     "export_format",
-    type=click.Choice(["json", "str", "table"]),
-    help="Format of to export data in",
+    type=click.Choice(list(EXPORT_FORMATS)),
+    help="Format to export data in",
     default="table",
     show_envvar=True,
     show_default=True,
 )
 
-ROLE_NAME = click.option(
+OPT_ROLE_NAME = click.option(
     "--name",
     "-n",
     "name",
@@ -26,12 +114,14 @@ ROLE_NAME = click.option(
     show_default=True,
 )
 
-PERMS = click.option(
+OPT_PERMS = click.option(
     "--perm",
     "-p",
     "perms",
-    help="""Permissions like $CATEGORY=$ACTION1,$ACTION2,...
-    Can use $CATEGORY_NAME=all or $CATEGORY_NAME=none (MULTIPLE)""",
+    help=(
+        "Permissions like $CATEGORY=$ACTION1,$ACTION2,... Can use $CATEGORY_NAME=all or "
+        "$CATEGORY_NAME=none (MULTIPLE)"
+    ),
     required=True,
     show_envvar=True,
     show_default=True,
@@ -40,47 +130,14 @@ PERMS = click.option(
 )
 
 
-def handle_export(ctx, data, export_format, **kwargs):
-    """Get roles."""
-    if export_format == "json":
-        click.secho(json_dump(data))
-        ctx.exit(0)
+OPT_DATA_SCOPE = click.option(
+    "--data-scope",
+    "-ds",
+    "data_scope",
+    help="Name or UUID of Data Scope restriction to apply",
+    required=False,
+    show_envvar=True,
+    show_default=True,
+)
 
-    if export_format == "str":
-        for item in listify(data):
-            name = item["name"]
-            perms = item["permissions_flat"]
-            grants = []
-
-            for category, actions in perms.items():
-                if all([v is True for k, v in actions.items()]):
-                    allows = "all"
-                elif all([v is False for k, v in actions.items()]):
-                    allows = "none"
-                else:
-                    allows = [k for k, v in actions.items() if v]
-                    allows = ",".join(allows)
-                grants.append(f"--perm {category}={allows!r}")
-
-            grants = " ".join(grants)
-            entry = f"--name {name!r} {grants}"
-            click.secho(entry)
-
-        ctx.exit(0)
-
-    if export_format == "table":
-        for item in listify(data):
-            name = item["name"]
-            last_updated = item["last_updated"]
-            perms = item["permissions_flat_descriptions"]
-
-            entry = [
-                f"Role {name!r}",
-                f"Updated: {last_updated}",
-            ]
-            entry = ", ".join(entry)
-            table = tabulate.tabulate(perms, tablefmt="simple", headers="keys")
-            click.secho(f"{entry}\n{table}\n")
-
-        ctx.exit(0)
-    ctx.exit(1)
+OPTS_EXPORT = [OPT_EXPORT, TABLE_FMT]

--- a/axonius_api_client/cli/grp_tools/cmd_shell.py
+++ b/axonius_api_client/cli/grp_tools/cmd_shell.py
@@ -22,6 +22,7 @@ API Objects:
     - activity_logs/al: Work with activity logs
     - adapters/a: Work with adapters and adapter connections
     - dashboard/db: Work with dashboards and discovery cycle
+    - data_scopes/ds: Work with data scopes
     - devices/d: Work with device assets
     - instances/i: Work with instances
     - meta/m: Work with instance metadata
@@ -67,6 +68,7 @@ def cmd(ctx, url, key, secret):  # noqa: D301
         - activity_logs/al: Work with activity logs
         - adapters/a: Work with adapters and adapter connections
         - dashboard/db: Work with dashboards and discovery cycle
+        - data_scopes/ds: Work with data scopes
         - devices/d: Work with device assets
         - instances/i: Work with instances
         - meta/m: Work with instance metadata
@@ -93,6 +95,7 @@ def cmd(ctx, url, key, secret):  # noqa: D301
         "ctx": ctx,
         "dashboard": client.dashboard,
         "devices": client.devices,
+        "data_scopes": client.data_scopes,
         "enforcements": client.enforcements,
         "instances": client.instances,
         "jdump": jdump,
@@ -111,6 +114,7 @@ def cmd(ctx, url, key, secret):  # noqa: D301
         "c": client,
         "d": client.devices,
         "db": client.dashboard,
+        "ds": client.data_scopes,
         "e": client.enforcements,
         "i": client.instances,
         "j": jdump,

--- a/axonius_api_client/connect.py
+++ b/axonius_api_client/connect.py
@@ -11,6 +11,7 @@ from .api import (
     ActivityLogs,
     Adapters,
     Dashboard,
+    DataScopes,
     Devices,
     Enforcements,
     Instances,
@@ -495,6 +496,14 @@ class Connect:
         if not hasattr(self, "_openapi"):
             self._openapi = OpenAPISpec(**self.API_ARGS)
         return self._openapi
+
+    @property
+    def data_scopes(self) -> DataScopes:
+        """Work with data scopes."""
+        self.start()
+        if not hasattr(self, "_data_scopes"):
+            self._data_scopes = DataScopes(**self.API_ARGS)
+        return self._data_scopes
 
     @classmethod
     def _get_exc_reason(cls, exc: Exception) -> str:

--- a/axonius_api_client/exceptions.py
+++ b/axonius_api_client/exceptions.py
@@ -329,3 +329,15 @@ class RequestLoadObjectError(RequestError):
 
 class ResponseLoadObjectError(RequestError):
     """Pass."""
+
+
+class FeatureNotEnabledError(ApiError):
+    """Pass."""
+
+    def __init__(self, name: str):
+        """Pass."""
+        msg = (
+            f"The {name} feature is not enabled on this instance, "
+            "please contact support@axonius.com to enable"
+        )
+        super().__init__(msg)

--- a/axonius_api_client/tests/conftest.py
+++ b/axonius_api_client/tests/conftest.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def api_devices(request):
     """Get a fully loaded Devices API object."""
-    from axonius_api_client.api import Adapters, Devices, Wizard, WizardCsv, WizardText
+    from axonius_api_client.api import Adapters, Devices, Wizard, WizardCsv, WizardText, DataScopes
     from axonius_api_client.api.assets import Fields, Labels, SavedQuery
 
     auth = get_auth(request)
@@ -64,14 +64,14 @@ def api_devices(request):
     assert isinstance(obj.wizard, Wizard)
     assert isinstance(obj.wizard_text, WizardText)
     assert isinstance(obj.wizard_csv, WizardCsv)
-
+    assert isinstance(obj.data_scopes, DataScopes)
     return obj
 
 
 @pytest.fixture(scope="session")
 def api_users(request):
     """Get a fully loaded Users API object."""
-    from axonius_api_client.api import Adapters, Users, Wizard, WizardCsv, WizardText
+    from axonius_api_client.api import Adapters, Users, Wizard, WizardCsv, WizardText, DataScopes
     from axonius_api_client.api.assets import Fields, Labels, SavedQuery
 
     auth = get_auth(request)
@@ -93,6 +93,7 @@ def api_users(request):
     assert isinstance(obj.wizard, Wizard)
     assert isinstance(obj.wizard_text, WizardText)
     assert isinstance(obj.wizard_csv, WizardCsv)
+    assert isinstance(obj.data_scopes, DataScopes)
 
     return obj
 
@@ -151,6 +152,19 @@ def api_system_roles(request):
     obj = SystemRoles(auth=auth)
     check_apiobj(authobj=auth, apiobj=obj)
     check_apiobj_xref(apiobj=obj, instances=Instances)
+
+    return obj
+
+
+@pytest.fixture(scope="session")
+def api_data_scopes(request):
+    """Test utility."""
+    from axonius_api_client.api import Instances, DataScopes, Users, Devices
+
+    auth = get_auth(request)
+    obj = DataScopes(auth=auth)
+    check_apiobj(authobj=auth, apiobj=obj)
+    check_apiobj_xref(apiobj=obj, instances=Instances, users=Users, devices=Devices)
 
     return obj
 

--- a/axonius_api_client/tests/tests_api/test_api_endpoints.py
+++ b/axonius_api_client/tests/tests_api/test_api_endpoints.py
@@ -3,7 +3,6 @@ from typing import List, Type
 
 import pytest
 import requests
-
 from axonius_api_client.api import json_api
 from axonius_api_client.api.api_endpoints import ApiEndpoint, ApiEndpointGroup, ApiEndpoints
 from axonius_api_client.exceptions import (
@@ -33,6 +32,8 @@ MODELS_EXCLUDE = [
     json_api.adapters.AdapterNodeCnx,
     json_api.adapters.AdapterClientsCount,
     json_api.adapters.AdapterNode,
+    json_api.saved_queries.Folder,
+    json_api.data_scopes.DataScope,
 ]
 
 SCHEMAS_EXCLUDE = [

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks.py
@@ -65,10 +65,10 @@ class Callbacks:
             apiobj=apiobj, cbexport=cbexport, getargs=getargs, state=state, store=store
         )
 
-    def get_row(self, apiobj):
-        if not hasattr(self, "_row"):
-            self._row = apiobj.get(max_rows=1)[0]
-        return copy.deepcopy(self._row)
+    @pytest.fixture(scope="class")
+    def original_row(self, apiobj):
+        row = apiobj.get(max_rows=1)[0]
+        yield row
 
 
 class CallbacksFull(Callbacks):
@@ -82,8 +82,7 @@ class CallbacksFull(Callbacks):
         cbobj.stop()
         log_check(caplog=caplog, entries=["Stopping"], exists=True)
 
-    def test_add_report_adapters_missing_false(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_add_report_adapters_missing_false(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -98,8 +97,7 @@ class CallbacksFull(Callbacks):
         assert isinstance(cbobj.custom_schemas, list)
         assert not cbobj.custom_schemas
 
-    def test_add_report_adapters_missing_true(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_add_report_adapters_missing_true(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -203,8 +201,7 @@ class CallbacksFull(Callbacks):
             assert original_row == rows[0]
             assert apiobj.FIELD_COMPLEX not in rows[0]
 
-    def test_do_add_null_values_exclude(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_add_null_values_exclude(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
         test_row.pop(apiobj.FIELD_ADAPTERS, None)
 
@@ -220,7 +217,7 @@ class CallbacksFull(Callbacks):
 
         assert apiobj.FIELD_ADAPTERS not in rows[0]
 
-    def test_do_custom_cb(self, cbexport, apiobj):
+    def test_do_custom_cb(self, cbexport, apiobj, original_row):
         def cb1(self, rows):
             for row in rows:
                 self._row_idx = getattr(self, "_row_idx", 0)
@@ -228,8 +225,6 @@ class CallbacksFull(Callbacks):
                 row["idx"] = self._row_idx
                 self._row_idx += 1
             return rows
-
-        original_row = self.get_row(apiobj=apiobj)
 
         cbobj = self.get_cbobj(
             apiobj=apiobj,
@@ -245,11 +240,9 @@ class CallbacksFull(Callbacks):
             assert idx == row["idx"]
             assert row["idcaps"] == row[apiobj.FIELD_AXON_ID].upper()
 
-    def test_do_custom_cb_fail(self, cbexport, apiobj):
+    def test_do_custom_cb_fail(self, cbexport, apiobj, original_row):
         def cb1(self, rows):
             raise ValueError("boom")
-
-        original_row = self.get_row(apiobj=apiobj)
 
         cbobj = self.get_cbobj(
             apiobj=apiobj,
@@ -264,8 +257,7 @@ class CallbacksFull(Callbacks):
         for x in cbobj.CUSTOM_CB_EXC:
             assert isinstance(x["exc"], ValueError)
 
-    def test_process_tags_to_add_remove(self, cbexport, apiobj, caplog):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_process_tags_to_add_remove(self, cbexport, apiobj, caplog, original_row):
         test_row = copy.deepcopy(original_row)
         row_id = test_row[apiobj.FIELD_AXON_ID]
         tags = [f"badwolf_{random_string(9)}", f"badwolf_{random_string(9)}"]
@@ -304,8 +296,7 @@ class CallbacksFull(Callbacks):
         for tag in tags:
             assert tag not in row_tags
 
-    def test_process_tags_to_add_empty(self, cbexport, apiobj, caplog):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_process_tags_to_add_empty(self, cbexport, apiobj, caplog, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"tags_add": []})
@@ -318,8 +309,7 @@ class CallbacksFull(Callbacks):
         cbobj.do_tagging()
         log_check(caplog=caplog, entries=["tags.*assets"], exists=False)
 
-    def test_process_tags_to_remove_empty(self, cbexport, apiobj, caplog):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_process_tags_to_remove_empty(self, cbexport, apiobj, caplog, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"tags_remove": []})
@@ -332,8 +322,7 @@ class CallbacksFull(Callbacks):
         cbobj.do_tagging()
         log_check(caplog=caplog, entries=["tags.*assets"], exists=False)
 
-    def test_do_excludes_empty(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_excludes_empty(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"field_excludes": []})
@@ -345,8 +334,7 @@ class CallbacksFull(Callbacks):
         else:
             assert test_row != original_row
 
-    def test_do_excludes(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_excludes(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         fields = [apiobj.FIELD_AXON_ID, apiobj.FIELD_ADAPTERS, "adapter_list_length"]
@@ -388,8 +376,7 @@ class CallbacksFull(Callbacks):
         for item in test_row[field_complex]:
             assert sub_name not in item
 
-    def test_do_join_values_true(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_join_values_true(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"field_join": True})
@@ -402,8 +389,7 @@ class CallbacksFull(Callbacks):
             if isinstance(original_row[field], list):
                 assert isinstance(test_row[field], str)
 
-    def test_do_join_values_false(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_join_values_false(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"field_join": False})
@@ -416,8 +402,8 @@ class CallbacksFull(Callbacks):
         else:
             assert original_row == test_row
 
-    def test_do_join_values_trim(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_join_values_trim(self, cbexport, apiobj, original_row):
+        original_row = copy.deepcopy(original_row)
         original_row["test"] = ("aaaa " * (FIELD_TRIM_LEN + 1000)).split()
         test_row = copy.deepcopy(original_row)
 
@@ -433,8 +419,8 @@ class CallbacksFull(Callbacks):
         test_len = len(test_row["test"])
         assert test_len <= exp_len
 
-    def test_do_join_values_trim_disabled(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_join_values_trim_disabled(self, cbexport, apiobj, original_row):
+        original_row = copy.deepcopy(original_row)
         original_row["test"] = ("aaaa " * (FIELD_TRIM_LEN + 1000)).split()
         test_row = copy.deepcopy(original_row)
 
@@ -451,8 +437,8 @@ class CallbacksFull(Callbacks):
         assert original_row != test_row
         assert "TRIMMED" not in test_row["test"]
 
-    def test_do_join_values_trim_custom_joiner(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_join_values_trim_custom_joiner(self, cbexport, apiobj, original_row):
+        original_row = copy.deepcopy(original_row)
         original_row["test"] = ("aaaa " * (FIELD_TRIM_LEN + 1000)).split()
         test_row = copy.deepcopy(original_row)
 
@@ -491,8 +477,7 @@ class CallbacksFull(Callbacks):
             assert cb_schema["name"] not in test_row
             assert cb_schema["name_qual"] not in test_row
 
-    def test_do_change_field_titles_false(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_change_field_titles_false(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"field_titles": False})
@@ -685,8 +670,7 @@ class CallbacksFull(Callbacks):
             for sub_schema in cbobj.get_sub_schemas(schema=cbobj.schema_to_explode):
                 assert sub_schema["name_qual"] in row
 
-    def test_do_explode_field_simple(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_explode_field_simple(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         key = apiobj.FIELD_ADAPTERS
@@ -708,8 +692,7 @@ class CallbacksFull(Callbacks):
             assert isinstance(value, str)
             assert value == row_val[idx]
 
-    def test_do_explode_field_exclude(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_explode_field_exclude(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -726,8 +709,7 @@ class CallbacksFull(Callbacks):
         assert len(rows) == 1
         assert test_row == rows[0]
 
-    def test_do_explode_field_none(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
+    def test_do_explode_field_none(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport)
@@ -890,9 +872,7 @@ class CallbacksFull(Callbacks):
         for field in fields:
             assert field in cbobj.final_columns
 
-    def test_do_field_replace_list_str(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
-
+    def test_do_field_replace_list_str(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -916,9 +896,7 @@ class CallbacksFull(Callbacks):
                 assert "." not in key
                 assert "i" not in key
 
-    def test_do_field_replace_list_list(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
-
+    def test_do_field_replace_list_list(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -942,9 +920,7 @@ class CallbacksFull(Callbacks):
                 assert "." not in key
                 assert "i" not in key
 
-    def test_do_field_replace_bad_types(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
-
+    def test_do_field_replace_bad_types(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(
@@ -960,9 +936,7 @@ class CallbacksFull(Callbacks):
         assert len(rows) == 1
         assert sorted(list(rows[0])) == sorted(list(original_row))
 
-    def test_do_field_replace_str_missing_rhs(self, cbexport, apiobj):
-        original_row = self.get_row(apiobj=apiobj)
-
+    def test_do_field_replace_str_missing_rhs(self, cbexport, apiobj, original_row):
         test_row = copy.deepcopy(original_row)
 
         cbobj = self.get_cbobj(

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_base.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_base.py
@@ -9,7 +9,7 @@ from .test_callbacks import CallbacksFull
 
 
 class TestCallbacksBase(CallbacksFull):
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_csv.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_csv.py
@@ -10,7 +10,7 @@ from .test_callbacks import Callbacks, Exports
 
 
 class TestCallbacksCsv(Callbacks, Exports):
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json.py
@@ -11,7 +11,7 @@ from .test_callbacks import Callbacks, Exports
 
 
 class TestCallbacksJson(Callbacks, Exports):
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json_to_csv.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_json_to_csv.py
@@ -9,7 +9,7 @@ from .test_callbacks import Callbacks, Exports
 
 
 class TestCallbacksJsonToCsv(Callbacks, Exports):
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_table.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_table.py
@@ -12,7 +12,7 @@ from .test_callbacks import Callbacks, Exports
 
 
 class TestCallbacksTable(Callbacks, Exports):
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_xlsx.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_xlsx.py
@@ -2,12 +2,11 @@
 """Test suite for assets."""
 
 import pytest
-
 from axonius_api_client.exceptions import ApiError
 
 
 class TestCallbacksXlsx:
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_xml.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks_xml.py
@@ -5,7 +5,7 @@ import pytest
 
 
 class TestCallbacksXml:
-    @pytest.fixture(params=["api_devices", "api_users"])
+    @pytest.fixture(params=["api_devices", "api_users"], scope="class")
     def apiobj(self, request):
         return request.getfixturevalue(request.param)
 

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -116,15 +116,6 @@ class SavedQueryPublic:
         with pytest.raises(AlreadyExists):
             apiobj.saved_query._check_name_exists(value=sq_fixture["name"])
 
-    def test__check_asset_scope_enabled(self, apiobj):
-        assert apiobj.saved_query._check_asset_scope_enabled(value=False) is None
-        flags = apiobj.instances._feature_flags()
-        if not flags.asset_scopes_enabled:
-            with pytest.raises(ApiError):
-                apiobj.saved_query._check_asset_scope_enabled(value=True)
-        else:
-            assert apiobj.saved_query._check_asset_scope_enabled(value=True) is None
-
     def test_get_no_generator(self, apiobj):
         rows = apiobj.saved_query.get(generator=False)
         assert not rows.__class__.__name__ == "generator"

--- a/axonius_api_client/tests/tests_api/tests_system/test_data_scopes.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_data_scopes.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Test suite."""
+import pytest
+from axonius_api_client.api import DataScopes, SystemRoles, json_api
+from axonius_api_client.exceptions import ApiError, NotFoundError
+from axonius_api_client.tools import listify
+
+
+class FixtureData:
+
+    name = "badwolf data scope"
+    name_update = f"{name} UPDATED"
+    names = [name, name_update]
+    description = "it bad wolfy"
+    description_update = f"{description} UPDATED"
+    asset_scope_devices1 = "badwolf asset scope for devices 1"
+    asset_scope_devices2 = "badwolf asset scope for devices 2"
+    asset_scope_users1 = "badwolf asset scope for users 1"
+    asset_scope_users2 = "badwolf asset scope for users 2"
+    asset_scopes_devices = [asset_scope_devices1, asset_scope_devices2]
+    asset_scopes_users = [asset_scope_users1, asset_scope_users2]
+    role = "badwolf role using data scope"
+
+
+class DataScopeFixtures:
+    def cleanup_data_scopes(self, apiobj, value):
+        for x in listify(value):
+            try:
+                apiobj.delete(value=x)
+            except ApiError:
+                pass
+
+    def cleanup_asset_scopes(self, apiasset, value):
+        try:
+            apiasset.saved_query.delete(rows=value, errors=False)
+        except ApiError:
+            pass
+
+    def cleanup_roles(self, apiobj, value):
+        if isinstance(apiobj, SystemRoles):
+            api_system_roles = apiobj
+        elif isinstance(apiobj, DataScopes):
+            api_system_roles = apiobj.system_roles
+
+        for x in listify(value):
+            try:
+                api_system_roles.delete_by_name(name=x)
+            except ApiError:
+                pass
+
+    def create_data_scope(self, apiobj, name, device_scopes, user_scopes):
+        self.cleanup_data_scopes(apiobj=apiobj, value=name)
+
+        row = apiobj.create(
+            name=FixtureData.name,
+            description=FixtureData.description,
+            device_scopes=device_scopes,
+            user_scopes=user_scopes,
+        )
+
+        assert str(row)
+        assert repr(row)
+        assert isinstance(row.updated_user_first_name, str)
+        assert isinstance(row.updated_user_last_name, str)
+        assert isinstance(row.updated_user_full_name, str)
+
+        yield row
+
+        self.cleanup_data_scopes(apiobj=apiobj, value=row.uuid)
+
+    def create_asset_scope(self, apiasset, name):
+        self.cleanup_asset_scopes(apiasset=apiasset, value=name)
+
+        row = apiasset.saved_query.add(
+            name=name,
+            asset_scope=True,
+            as_dataclass=True,
+        )
+
+        yield row
+
+        self.cleanup_asset_scopes(apiasset=apiasset, value=row.uuid)
+
+    @pytest.fixture(scope="class")
+    def f_data_scope(self, api_data_scopes, f_asset_scope_devices1, f_asset_scope_users1):
+        yield from self.create_data_scope(
+            apiobj=api_data_scopes,
+            name=FixtureData.name,
+            device_scopes=f_asset_scope_devices1,
+            user_scopes=f_asset_scope_users1,
+        )
+
+    @pytest.fixture(scope="class")
+    def f_asset_scope_devices1(self, api_data_scopes):
+        yield from self.create_asset_scope(
+            apiasset=api_data_scopes.devices, name=FixtureData.asset_scope_devices1
+        )
+
+    @pytest.fixture(scope="class")
+    def f_asset_scope_devices2(self, api_data_scopes):
+        yield from self.create_asset_scope(
+            apiasset=api_data_scopes.devices, name=FixtureData.asset_scope_devices2
+        )
+
+    @pytest.fixture(scope="class")
+    def f_asset_scope_users1(self, api_data_scopes):
+        yield from self.create_asset_scope(
+            apiasset=api_data_scopes.users, name=FixtureData.asset_scope_users1
+        )
+
+    @pytest.fixture(scope="class")
+    def f_asset_scope_users2(self, api_data_scopes):
+        yield from self.create_asset_scope(
+            apiasset=api_data_scopes.users, name=FixtureData.asset_scope_users2
+        )
+
+
+class DataScopesBase(DataScopeFixtures):
+    @pytest.fixture(scope="class")
+    def apiobj(self, api_data_scopes):
+        if not api_data_scopes.is_feature_enabled:
+            pytest.skip("Data Scopes Feature Flag not enabled")
+        self.cleanup_data_scopes(apiobj=api_data_scopes, value=FixtureData.names)
+        self.cleanup_asset_scopes(
+            apiasset=api_data_scopes.users, value=FixtureData.asset_scopes_users
+        )
+        self.cleanup_asset_scopes(
+            apiasset=api_data_scopes.devices, value=FixtureData.asset_scopes_devices
+        )
+        return api_data_scopes
+
+
+class TestDataScopesPublic(DataScopesBase):
+    def test_get(self, apiobj, f_data_scope):
+        items = apiobj.get()
+        assert isinstance(items, list) and items
+        for item in items:
+            assert isinstance(item, json_api.data_scopes.DataScope)
+
+    def test_get_safe(self, api_data_scopes):
+        items = api_data_scopes.get_safe()
+        assert isinstance(items, list)
+
+    def test_get_value_name(self, apiobj, f_data_scope):
+        item = apiobj.get(value=f_data_scope.name)
+        assert isinstance(item, json_api.data_scopes.DataScope)
+        assert item.name == f_data_scope.name
+
+    def test_get_value_uuid(self, apiobj, f_data_scope):
+        item = apiobj.get(value=f_data_scope.uuid)
+        assert isinstance(item, json_api.data_scopes.DataScope)
+        assert item.name == f_data_scope.name
+
+    def test_get_value_fail(self, apiobj, f_data_scope):
+        with pytest.raises(NotFoundError):
+            apiobj.get(value="I DO NOT EXISTSSSS")
+
+    def test_update_name(self, apiobj, f_data_scope):
+        item = apiobj.update_name(value=f_data_scope, update=FixtureData.name_update)
+        assert item.name == FixtureData.name_update
+
+    def test_update_description(self, apiobj, f_data_scope):
+        item = apiobj.update_description(value=f_data_scope, update=FixtureData.description_update)
+        assert item.description == FixtureData.description_update
+
+    def test_update_name_fail(self, apiobj, f_data_scope):
+        with pytest.raises(ApiError):
+            apiobj.update_name(value=f_data_scope.name, update=f_data_scope.name)
+
+    def test_create_fail_no_scopes(self, apiobj):
+        with pytest.raises(ApiError):
+            apiobj.create(name="d i r t")
+
+    def test_update_user_scopes(self, apiobj, f_data_scope, f_asset_scope_users2):
+        original_queries = f_data_scope.users_queries
+        item = apiobj.update_user_scopes(
+            value=f_data_scope, update=f_asset_scope_users2.name, append=True
+        )
+        assert item.users_queries == original_queries + [f_asset_scope_users2.uuid]
+
+        item = apiobj.update_user_scopes(
+            value=f_data_scope, update=f_asset_scope_users2.name, remove=True
+        )
+        assert f_asset_scope_users2.uuid not in item.users_queries
+
+        item = apiobj.update_user_scopes(value=f_data_scope, update=original_queries)
+        assert item.users_queries == original_queries
+
+    def test_update_user_scopes_fail_empty_init(self, apiobj, f_data_scope):
+        with pytest.raises(ApiError):
+            apiobj.update_user_scopes(value=f_data_scope, update=[])
+
+    def test_update_user_scopes_fail_empty_update(self, apiobj, f_data_scope, monkeypatch):
+        monkeypatch.setattr(f_data_scope, "devices_queries", [])
+        with pytest.raises(ApiError):
+            f_data_scope.update_scopes(
+                scope_type="users", scopes=f_data_scope.users_scopes, remove=True
+            )
+
+    def test_update_device_scopes(self, apiobj, f_data_scope, f_asset_scope_devices2):
+        original_queries = f_data_scope.devices_queries
+        item = apiobj.update_device_scopes(
+            value=f_data_scope, update=f_asset_scope_devices2.name, append=True
+        )
+        assert item.devices_queries == original_queries + [f_asset_scope_devices2.uuid]
+
+        item = apiobj.update_device_scopes(
+            value=f_data_scope, update=f_asset_scope_devices2.name, remove=True
+        )
+        assert f_asset_scope_devices2.uuid not in item.devices_queries
+
+        item = apiobj.update_device_scopes(value=f_data_scope, update=original_queries)
+        assert item.devices_queries == original_queries
+
+    def test_update_device_scopes_fail_empty_init(self, apiobj, f_data_scope):
+        with pytest.raises(ApiError):
+            apiobj.update_device_scopes(value=f_data_scope, update=[])
+
+    def test_update_device_scopes_fail_empty_update(self, apiobj, f_data_scope, monkeypatch):
+        monkeypatch.setattr(f_data_scope, "users_queries", [])
+        with pytest.raises(ApiError):
+            f_data_scope.update_scopes(
+                scope_type="devices", scopes=f_data_scope.devices_scopes, remove=True
+            )
+
+    def test_build_role_data_scope(self, apiobj, f_data_scope):
+        exp = {"enabled": True, "data_scope": f_data_scope.uuid}
+        data = apiobj.build_role_data_scope(value=f_data_scope, required=True)
+        assert data == exp
+
+    def test_build_role_data_scope_required(self, api_data_scopes):
+        with pytest.raises(ApiError):
+            api_data_scopes.build_role_data_scope(value=None, required=True)
+
+    def test_build_role_data_scope_not_required(self, api_data_scopes):
+        exp = {"enabled": False, "data_scope": None}
+        data = api_data_scopes.build_role_data_scope(value=None, required=False)
+        assert data == exp
+
+    def test_role_add_data_scope(self, apiobj, f_data_scope):
+        self.cleanup_roles(apiobj=apiobj, value=FixtureData.role)
+        exp = {"enabled": True, "data_scope": f_data_scope.uuid}
+        role = apiobj.system_roles.add(name=FixtureData.role, data_scope=f_data_scope)
+        assert role["data_scope_restriction"] == exp
+        self.cleanup_roles(apiobj=apiobj, value=FixtureData.role)
+
+    def test_role_update_data_scope(self, apiobj, f_data_scope):
+        self.cleanup_roles(apiobj=apiobj, value=FixtureData.role)
+
+        exp = {"enabled": False, "data_scope": None}
+        role = apiobj.system_roles.add(name=FixtureData.role)
+        assert role["data_scope_restriction"] == exp
+
+        exp = {"enabled": True, "data_scope": f_data_scope.uuid}
+        role = apiobj.system_roles.update_data_scope(name=FixtureData.role, data_scope=f_data_scope)
+        assert role["data_scope_restriction"] == exp
+
+        exp = {"enabled": False, "data_scope": None}
+        role = apiobj.system_roles.update_data_scope(name=FixtureData.role, remove=True)
+        assert role["data_scope_restriction"] == exp
+
+        self.cleanup_roles(apiobj=apiobj, value=FixtureData.role)

--- a/axonius_api_client/tests/tests_api/tests_system/test_instances.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_instances.py
@@ -3,7 +3,6 @@
 import datetime
 
 import pytest
-
 from axonius_api_client.api import json_api
 from axonius_api_client.api.api_endpoints import ApiEndpoints
 from axonius_api_client.exceptions import NotFoundError
@@ -89,7 +88,7 @@ class TestInstancesPublic:
         assert isinstance(value, json_api.system_settings.FeatureFlags)
         assert isinstance(value.config, dict)
         assert isinstance(value.document_meta["schema"], dict)
-        assert isinstance(value.asset_scopes_max, (int, type(None)))
+        assert isinstance(value.data_scopes_max, (int, type(None)))
 
     def test_has_cloud_compliance(self, apiobj):
         value = apiobj.has_cloud_compliance

--- a/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/__init__.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Test suite."""

--- a/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/base.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/base.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_system.test_data_scopes import DataScopeFixtures, FixtureData
+
+
+class Meta:
+    """Pass."""
+
+    name = "badwolf CLI"
+    name_update = f"{name} UPDATED"
+    names = [name, name_update]
+    fixture_data = FixtureData
+
+
+class DataScopesBase(DataScopeFixtures):
+    """Pass."""
+
+    @pytest.fixture(scope="class")
+    def apiobj(self, api_data_scopes):
+        """Pass."""
+        if not api_data_scopes.is_feature_enabled:
+            pytest.skip("Data Scopes Feature Flag not enabled")
+
+        return api_data_scopes
+
+    def check_result(self, result, exit_codes=[0]):
+        """Pass."""
+        assert result.stdout
+        assert result.stderr
+        assert result.exit_code in exit_codes
+
+        data = json_load(result.stdout)
+        assert isinstance(data, (list, dict))
+        if isinstance(data, list):
+            for i in data:
+                assert isinstance(i, dict)
+        return data

--- a/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/test_cmd_create.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/test_cmd_create.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import DataScopesBase, Meta
+
+
+class TestGrpDataScopesCmdCreate(DataScopesBase):
+    def test_create_update_delete(
+        self,
+        apiobj,
+        request,
+        monkeypatch,
+        f_asset_scope_users1,
+        f_asset_scope_devices1,
+        f_asset_scope_devices2,
+    ):
+        self.cleanup_data_scopes(apiobj=apiobj, value=Meta.names)
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            name = Meta.name
+            args = [
+                "system",
+                "data-scopes",
+                "create",
+                "--name",
+                name,
+                "--device-scope",
+                f_asset_scope_devices1.name,
+                "--device-scope",
+                f_asset_scope_devices2.name,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            name = self.check_result(result=result)["name"]
+
+            args = [
+                "system",
+                "data-scopes",
+                "update-description",
+                "--value",
+                name,
+                "--update",
+                "fooooooooo",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            name = self.check_result(result=result)["name"]
+
+            args = [
+                "system",
+                "data-scopes",
+                "update-name",
+                "--value",
+                name,
+                "--update",
+                Meta.name_update,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            name = self.check_result(result=result)["name"]
+
+            args = [
+                "system",
+                "data-scopes",
+                "update-user-scopes",
+                "--value",
+                name,
+                "--update",
+                f_asset_scope_users1.uuid,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            name = self.check_result(result=result)["name"]
+
+            args = [
+                "system",
+                "data-scopes",
+                "update-device-scopes",
+                "--value",
+                name,
+                "--update",
+                f_asset_scope_devices2.uuid,
+                "--remove",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            name = self.check_result(result=result)["name"]
+
+            args = [
+                "system",
+                "data-scopes",
+                "delete",
+                "--value",
+                name,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+        self.cleanup_data_scopes(apiobj=apiobj, value=Meta.names)

--- a/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/test_cmd_get.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_data_scopes/test_cmd_get.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import DataScopesBase
+
+
+class TestGrpDataScopesCmdGet(DataScopesBase):
+    def test_json(self, apiobj, request, monkeypatch, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "data-scopes",
+                "get",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+    @pytest.mark.parametrize("str_format", ["str", "table"], scope="class")
+    def test_str_types(self, apiobj, request, monkeypatch, str_format, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "data-scopes",
+                "get",
+                "--export-format",
+                str_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0
+
+    def test_json_value(self, apiobj, request, monkeypatch, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "data-scopes",
+                "get",
+                "--value",
+                f_data_scope.uuid,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+    @pytest.mark.parametrize("str_format", ["str", "table"], scope="class")
+    def test_str_types_value(self, apiobj, request, monkeypatch, str_format, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "data-scopes",
+                "get",
+                "--value",
+                f_data_scope.uuid,
+                "--export-format",
+                str_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/__init__.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Test suite."""

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/base.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/base.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+from axonius_api_client.tools import json_load
+
+from ...tests_api.tests_system.test_data_scopes import DataScopeFixtures
+
+
+class Meta:
+    """Pass."""
+
+    admin = "Admin"
+    name = "badwolf CLI"
+    name_update = f"{name} UPDATED"
+    names = [name, name_update]
+
+
+class SystemRolesBase(DataScopeFixtures):
+    """Pass."""
+
+    @pytest.fixture(scope="class")
+    def apiobj(self, api_system_roles):
+        """Pass."""
+        return api_system_roles
+
+    def check_result(self, result, exit_codes=[0]):
+        """Pass."""
+        assert result.stdout
+        assert result.stderr
+        assert result.exit_code in exit_codes
+
+        data = json_load(result.stdout)
+        assert isinstance(data, (list, dict))
+        if isinstance(data, list):
+            for i in data:
+                assert isinstance(i, dict)
+        return data

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_add.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_add.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdAdd(SystemRolesBase):
+    def test_add(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=all",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)
+
+    def test_add_data_scope(self, apiobj, request, monkeypatch, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            name = "badwolf CLI data scope"
+            self.cleanup_roles(apiobj=apiobj, value=name)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                name,
+                "--perm",
+                "adapters=all",
+                "--data-scope",
+                f_data_scope.uuid,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+            self.cleanup_roles(apiobj=apiobj, value=name)

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_delete.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_delete.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdDelete(SystemRolesBase):
+    def test_delete(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=all",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            args = [
+                "system",
+                "roles",
+                "delete",
+                "--name",
+                Meta.name,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import SystemRolesBase
+
+
+class TestGrpSystemRolesCmdGet(SystemRolesBase):
+    def test_json(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "roles",
+                "get",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+    @pytest.mark.parametrize("str_format", ["str", "str-args", "table"], scope="class")
+    def test_str_types(self, apiobj, request, monkeypatch, str_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "roles",
+                "get",
+                "--export-format",
+                str_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get_by_name.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get_by_name.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdGetByName(SystemRolesBase):
+    def test_json(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "roles",
+                "get-by-name",
+                "--name",
+                Meta.admin,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+    @pytest.mark.parametrize("str_format", ["str", "str-args", "table"], scope="class")
+    def test_str_types(self, apiobj, request, monkeypatch, str_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "roles",
+                "get-by-name",
+                "--name",
+                Meta.admin,
+                "--export-format",
+                str_format,
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get_perms.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_get_perms.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import SystemRolesBase
+
+
+class TestGrpSystemRolesCmdGetPerms(SystemRolesBase):
+    def test_str_types(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args = [
+                "system",
+                "roles",
+                "get-perms",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+
+            assert result.stdout
+            assert result.stderr
+            assert result.exit_code == 0

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_data_scope.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_data_scope.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdUpdateDataScope(SystemRolesBase):
+    def test_update_data_scope(self, apiobj, request, monkeypatch, f_data_scope):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=all",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            args = [
+                "system",
+                "roles",
+                "update-data-scope",
+                "--name",
+                Meta.name,
+                "--data-scope",
+                f_data_scope.uuid,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            args = [
+                "system",
+                "roles",
+                "update-data-scope",
+                "--name",
+                Meta.name,
+                "--remove",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_name.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_name.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdUpdateName(SystemRolesBase):
+    def test_update_name(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            self.cleanup_roles(apiobj=apiobj, value=Meta.names)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=all",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            args = [
+                "system",
+                "roles",
+                "update-name",
+                "--name",
+                Meta.name,
+                "--new-name",
+                Meta.name_update,
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            self.cleanup_roles(apiobj=apiobj, value=Meta.names)

--- a/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_perms.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_system_roles/test_cmd_update_perms.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+from ....cli import cli
+from ...utils import load_clirunner
+from .base import Meta, SystemRolesBase
+
+
+class TestGrpSystemRolesCmdUpdatePerms(SystemRolesBase):
+    def test_update_perms(self, apiobj, request, monkeypatch):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)
+            args = [
+                "system",
+                "roles",
+                "add",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=all",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            args = [
+                "system",
+                "roles",
+                "update-perms",
+                "--name",
+                Meta.name,
+                "--perm",
+                "adapters=connections.delete,connections.post",
+                "--deny",
+                "--export-format",
+                "json",
+            ]
+            result = runner.invoke(cli=cli, args=args)
+            self.check_result(result=result)
+
+            self.cleanup_roles(apiobj=apiobj, value=Meta.name)

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.30.0"
+__version__ = "4.30.1"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.30.1](#4301)
  - [AXONSHELL](#axonshell)
    - [AXONSHELL enhancements](#axonshell-enhancements)
  - [API Library](#api-library)
    - [API Library Enhancements](#api-library-enhancements)

<!-- /MarkdownTOC -->

# 4.30.1

## AXONSHELL

### AXONSHELL enhancements

- NEW COMMAND GROUP: 
  - `axonshell system data-scopes` - work with data scopes, commands:
    - `axonshell system data-scopes create` - Create a data scope.
    - `axonshell system data-scopes delete` - Delete a data scope.
    - `axonshell system data-scopes get` - Get data scopes.
    - `axonshell system data-scopes update-description` - Update the description of a data scope.
    - `axonshell system data-scopes update-device-scopes` - Update the device asset scopes of a data scope.
    - `axonshell system data-scopes update-name` - Update the name of a data scope.
    - `axonshell system data-scopes update-user-scopes` - Update the user asset scopes of a data scope.

- NEW ARGUMENTS: 
  - For command `axonshell system roles add`:
    - `--data-scope/-ds` - Specify a data scope to associate with the role

- NEW COMMANDS: 
  - For command group `axonshell system roles`:
    - `axonshell system roles update-data-scope` - Update a roles data scope.
    - `axonshell system roles get-perms` - Get a print out of all role permission categories and actions.

- MODIFIED ARGUMENTS: 
  - For all commands in command group `axonshell system roles`:
    - `--export-format/-xf`:
      - Now supports `str-args`
      - `str` format changed, to get the old str format use `str-args`
      - Default format is now `table`
      - Added more metadata to output

## API Library

### API Library Enhancements
- `client.data_scopes` - new api model for working with data scopes
  - `client.data_scopes.get` - get data scopes 
  - `client.data_scopes.get_safe` - get data scopes (will not error if data scope feature not enabled)
  - `client.data_scopes.build_role_data_scope` - build a data scope restriction for use in a system role
  - `client.data_scopes.create` - create a data scope
  - `client.data_scopes.delete`  - delete a data scope
  - `client.data_scopes.update_name` - update the name of a data scope
  - `client.data_scopes.update_description` - update the description of a data scope
  - `client.data_scopes.update_user_scopes` - update the user asset scopes of a data scope
  - `client.data_scopes.update_device_scopes` - update the device asset scopes of a data scope
  - `client.data_scopes.check_feature_enabled` - throw an exception if data scope feature is not enabled
  - `client.data_scopes.is_feature_enabled` - check if data scope feature is enabled
  - `client.data_scopes.check_exists` - check if a data scope already exists with a name
  - `client.data_scopes.get_asset_scopes` - get all saved query's that are asset scopes for users and devices
  - `client.data_scopes._get` - private direct API method to get data scopes
  - `client.data_scopes._delete` - private direct API method to delete a data scope
  - `client.data_scopes._create` - private direct API method to create a data scope
  - `client.data_scopes._update` - private direct API method to update a data scope
  - `client.data_scopes._update_from_model` - private direct API method to update a data scope

- `client.system_roles` - new methods:
  - `client.system_roles.update_data_scope` - Update the data scope for a role

- `client.system_roles.add` - new arguments:
  - `data_scope` optional string with name or UUID of data scope for the role
