### PR TITLE
bonzai

### DIFF
--- a/axonius_api_client/api/asset_callbacks/base.py
+++ b/axonius_api_client/api/asset_callbacks/base.py
@@ -1219,7 +1219,7 @@ class ExportMixins(Base):
         self._fd_close: bool = False
         self._fd: IO = sys.stdout
         self._fd_info: str = "stdout"
-        self.echo(msg="Exporting to {self._fd_info}")
+        self.echo(msg=f"Exporting to {self._fd_info}")
         return self._fd
 
     def close_fd(self):

--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -810,6 +810,7 @@ class AdaptersList(Metadata):
                 "title": x["title"],
                 "name_raw": x["name"],
                 "name": get_aname(x["name"]),
+                "clients": x.get("clients"),
             }
             for x in items
         }

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -145,7 +145,8 @@ class Parsers(BaseEnum):
     to_str_escaped_regex = enum.auto()
     to_str_subnet = enum.auto()
     to_str_tags = enum.auto()
-    to_str_sq_name = enum.auto()
+    to_str_sq = enum.auto()
+    to_str_data_scope = enum.auto()
 
 
 class Types(BaseEnum):
@@ -175,8 +176,9 @@ class Formats(BaseEnum):
     os_distribution = "os-distribution"
     dynamic_field = enum.auto()
     date = enum.auto()  # added 4.5
-    sq_name = enum.auto()
+    sq = enum.auto()
     expirable_tag = "expirable-tag"
+    data_scope = enum.auto()
 
 
 @dataclasses.dataclass
@@ -282,11 +284,17 @@ class Operators(BaseData):
         template='("{field}" == "{aql_value}")',
         parser=Parsers.to_str_cnx_label,
     )
-    equals_str_sq_name: Operator = Operator(
+    equals_str_sq: Operator = Operator(
         name_map=OperatorNameMaps.equals_empty,
         template="({{{{QueryID={aql_value}}}}})",
-        parser=Parsers.to_str_sq_name,
+        parser=Parsers.to_str_sq,
         field_name_override="saved_query",
+    )
+    equals_str_data_scope: Operator = Operator(
+        name_map=OperatorNameMaps.equals_empty,
+        template="({{{{AssetScopeID={aql_value}}}}})",
+        parser=Parsers.to_str_data_scope,
+        field_name_override="data_scope",
     )
     equals_ip: Operator = Operator(
         name_map=OperatorNameMaps.equals,
@@ -466,14 +474,32 @@ class OperatorTypeMap(BaseData):
 class OperatorTypeMaps(BaseData):
     """Operator type map that maps operators to a specific field schemas."""
 
-    string_sq_name: OperatorTypeMap = OperatorTypeMap(
-        name="string_sq_name",
+    string_sq: OperatorTypeMap = OperatorTypeMap(
+        name="string_sq",
         operators=[
-            Operators.equals_str_sq_name,
+            Operators.equals_str_sq,
         ],
         field_type=Types.string,
-        field_format=Formats.sq_name,
+        field_format=Formats.sq,
     )
+    """
+    simple sq equals Name Of Saved Query
+    simple sq equals UUID_OF_SQ
+    """
+
+    string_data_scope: OperatorTypeMap = OperatorTypeMap(
+        name="string_data_scope",
+        operators=[
+            Operators.equals_str_data_scope,
+        ],
+        field_type=Types.string,
+        field_format=Formats.data_scope,
+    )
+    """
+    simple data_scope equals Name Of Data Scope
+    simple data_scope equals UUID_OF_DATA_SCOPE
+    """
+
     string_cnx_label: OperatorTypeMap = OperatorTypeMap(
         name="string_cnx_label",
         operators=[
@@ -484,6 +510,12 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.connection_label,
     )
+    """
+    simple connection_label exists
+    simple connection_label equals abc
+    simple connection_label in abc,def,ghi
+    """
+
     string: OperatorTypeMap = OperatorTypeMap(
         name="string",
         operators=[
@@ -497,18 +529,38 @@ class OperatorTypeMaps(BaseData):
         ],
         field_type=Types.string,
     )
+    """
+    simple agg:name exists
+    simple agg:name regex a.*
+    simple agg:name contains test
+    simple agg:name equals test
+    simple agg:name startswith a
+    simple agg:name endswith a
+    simple agg:name in test,demo
+    """
+
     string_os_distribution: OperatorTypeMap = OperatorTypeMap(
         name="string_os_distribution",
         operators=string.operators,
         field_type=Types.string,
         field_format=Formats.os_distribution,
     )
+    """
+    simple os.distribution exists
+    simple os.distribution equals Server 2012
+    """
+
     string_expirable_tag: OperatorTypeMap = OperatorTypeMap(
         name="string_os_expirable_tag",
         operators=string.operators,
         field_type=Types.string,
         field_format=Formats.expirable_tag,
     )
+    """
+    simple expirable_tags.name exists
+    simple expirable_tags.name equals bravozulu
+    """
+
     string_ip: OperatorTypeMap = OperatorTypeMap(
         name="string_ip",
         operators=[
@@ -525,6 +577,7 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.ip,
     )
+
     string_datetime: OperatorTypeMap = OperatorTypeMap(
         name="string_datetime",
         operators=[
@@ -539,6 +592,16 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.datetime,
     )
+    """
+    simple first_seen exists
+    simple first_seen less_than 2022-06-01
+    simple first_seen more_than 2022-06-01
+    simple first_seen last_hours 10
+    simple first_seen next_hours 10
+    simple first_seen last_days 1
+    simple first_seen next_days 1
+    """
+
     string_date: OperatorTypeMap = OperatorTypeMap(
         name="string_date",
         operators=[
@@ -553,12 +616,14 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.date,
     )
+
     string_image: OperatorTypeMap = OperatorTypeMap(
         name="string_image",
         operators=[Operators.exists],
         field_type=Types.string,
         field_format=Formats.image,
     )
+
     string_version: OperatorTypeMap = OperatorTypeMap(
         name="string_version",
         operators=[
@@ -573,6 +638,13 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.version,
     )
+    """
+    simple installed_software.version exists
+    simple installed_software.version equals 7.0
+    complex installed_software // name contains a // version equals 7.0
+    complex installed_software // name equals Google Chrome // version earlier_than 100.0
+    """
+
     string_subnet: OperatorTypeMap = OperatorTypeMap(
         name="string_subnet",
         operators=[
@@ -585,11 +657,17 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.string,
         field_format=Formats.subnet,
     )
+
     boolean: OperatorTypeMap = OperatorTypeMap(
         name="boolean",
         operators=[Operators.is_true, Operators.is_false],
         field_type=Types.boolean,
     )
+    """
+    simple from_last_fetch true
+    simple from_last_fetch false
+    """
+
     integer: OperatorTypeMap = OperatorTypeMap(
         name="integer",
         operators=[
@@ -601,17 +679,38 @@ class OperatorTypeMaps(BaseData):
         ],
         field_type=Types.integer,
     )
+    """
+    simple agg:not_fetched_count exists
+    simple agg:not_fetched_count equals 2
+    simple agg:not_fetched_count in 2,3,4
+    simple agg:not_fetched_count more_than 1
+    simple agg:not_fetched_count less_than 2
+    """
+
     number: OperatorTypeMap = OperatorTypeMap(
         name="number",
         operators=integer.operators,
         field_type=Types.number,
     )
+    """
+    simple agg:software_cves.cvss exists
+    simple agg:software_cves.cvss equals 7.5
+    simple agg:software_cves.cvss in 7.5,7.0
+    simple agg:software_cves.cvss more_than 7.0
+    simple agg:software_cves.cvss less_than 7.0
+    """
+
     array_object: OperatorTypeMap = OperatorTypeMap(
         name="array_object",
         operators=[Operators.exists_array_object, Operators.count_equals],
         field_type=Types.array,
         items_type=Types.array,
     )
+    """
+    simple cpus exists
+    simple cpus count_equals 2
+    """
+
     array_table_object: OperatorTypeMap = OperatorTypeMap(
         name="array_table_object",
         operators=array_object.operators,
@@ -619,6 +718,11 @@ class OperatorTypeMaps(BaseData):
         field_format=Formats.table,
         items_type=Types.array,
     )
+    """
+    simple open_ports exists
+    simple open_ports count_equals 2
+    """
+
     array_integer: OperatorTypeMap = OperatorTypeMap(
         name="array_integer",
         operators=[
@@ -628,6 +732,7 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.array,
         items_type=Types.integer,
     )
+
     array_number: OperatorTypeMap = OperatorTypeMap(
         name="array_number",
         operators=[
@@ -637,6 +742,7 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.array,
         items_type=Types.number,
     )
+
     array_string: OperatorTypeMap = OperatorTypeMap(
         name="array_string",
         operators=[
@@ -646,6 +752,13 @@ class OperatorTypeMaps(BaseData):
         field_type=Types.array,
         items_type=Types.string,
     )
+    """
+    simple last_used_users exists
+    simple last_used_users equals Administrator
+    simple last_used_users in Administrator,test
+    simple last_used_users contains test
+    """
+
     array_string_tag: OperatorTypeMap = OperatorTypeMap(
         name="array_string_tag",
         operators=[
@@ -662,6 +775,12 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.tag,
     )
+    """
+    simple labels exists
+    simple labels count_equals 1
+    simple labels equals aaaa
+    """
+
     array_string_version: OperatorTypeMap = OperatorTypeMap(
         name="array_string_version",
         operators=[
@@ -673,6 +792,7 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.version,
     )
+
     array_string_datetime: OperatorTypeMap = OperatorTypeMap(
         name="array_string_datetime",
         operators=[
@@ -684,6 +804,7 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.datetime,
     )
+
     array_string_subnet: OperatorTypeMap = OperatorTypeMap(
         name="array_string_subnet",
         operators=[
@@ -695,6 +816,12 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.subnet,
     )
+    """
+    simple network_interfaces.subnets exists
+    simple network_interfaces.subnets equals 10.240.0.0/16
+    simple network_interfaces.subnets in 10.240.0.0/16,10.0.1.0/24
+    """
+
     array_discrete_string_logo: OperatorTypeMap = OperatorTypeMap(
         name="array_discrete_string_logo",
         operators=[
@@ -710,6 +837,16 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.logo,
     )
+    """
+    simple adapters exists
+    simple adapters equals aws
+    simple adapters equals tanium asset
+    simple adapters count_equals 1
+    simple adapters count_below 2
+    simple adapters count_above 1
+    simple adapters in aws, tanium asset
+    """
+
     array_string_ip: OperatorTypeMap = OperatorTypeMap(
         name="array_string_ip",
         operators=[
@@ -721,6 +858,18 @@ class OperatorTypeMaps(BaseData):
         items_type=Types.string,
         items_format=Formats.ip,
     )
+    """
+    simple public_ips exists
+    simple public_ips regex ^10.*
+    simple public_ips contains .0
+    simple public_ips in 10.0.0.1,10.0.0.2
+    simple public_ips equals 10.0.0.1
+    simple public_ips in_subnet 1.1.2.0/24
+    simple public_ips not_in_subnet 1.1.2.0/24
+    simple public_ips is_ipv4
+    simple public_ips is_ipv6
+    """
+
     array_string_ip_preferred: OperatorTypeMap = OperatorTypeMap(
         name="array_string_ip_preferred",
         operators=[
@@ -818,8 +967,8 @@ CUSTOM_FIELDS_MAP: Dict[str, List[dict]] = {
             "name_base": "connection_label",
             "name_qual": "specific_data.connection_label",
             "title": "Adapter Connection Label",
-            "type": "string",
-            "format": "connection_label",
+            "type": Types.string.value,
+            "format": Formats.connection_label.value,
             "type_norm": "string_cnx_label",
             "is_agg": True,
             "selectable": True,
@@ -843,9 +992,34 @@ CUSTOM_FIELDS_MAP: Dict[str, List[dict]] = {
             "name_base": "sq",
             "name_qual": "specific_data.sq",
             "title": "Saved Query Name",
-            "type": "string",
-            "format": "sq_name",
-            "type_norm": "string_sq_name",
+            "type": Types.string.value,
+            "format": Formats.sq.value,
+            "type_norm": "string_sq",
+            "is_agg": True,
+            "selectable": True,
+            "expr_field_type": AGG_EXPR_FIELD_TYPE,
+            "is_details": False,
+            "is_all": False,
+        },
+        {
+            "adapter_name_raw": f"{AGG_ADAPTER_NAME}_adapter",
+            "adapter_name": AGG_ADAPTER_NAME,
+            "adapter_title": AGG_ADAPTER_TITLE,
+            "adapter_prefix": "specific_data",
+            "column_name": f"{AGG_ADAPTER_NAME}:data_scope",
+            "column_title": f"{AGG_ADAPTER_TITLE}: Data Scope Name",
+            "sub_fields": [],
+            "is_complex": False,
+            "is_list": False,
+            "is_root": True,
+            "parent": "root",
+            "name": "specific_data.data_scope",
+            "name_base": "data_scope",
+            "name_qual": "specific_data.data_scope",
+            "title": "Data Scope Name",
+            "type": Types.string.value,
+            "format": Formats.data_scope.value,
+            "type_norm": "string_data_scope",
             "is_agg": True,
             "selectable": True,
             "expr_field_type": AGG_EXPR_FIELD_TYPE,

--- a/axonius_api_client/constants/wizards.py
+++ b/axonius_api_client/constants/wizards.py
@@ -60,7 +60,7 @@ class Patterns:
 
     OP_ALPHA: str = re.compile(
         r"""(?ix)        # case insensitive and verbose
-([^a-z_\-])  # contains characters that are not one of: a-z _ -
+([^a-z0-9_\-])  # contains characters that are not one of: a-z 0-9 _ -
 """
     )
     """regex for validating operators"""

--- a/axonius_api_client/parsers/wizards.py
+++ b/axonius_api_client/parsers/wizards.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Parser for query wizards."""
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from cachetools import TTLCache, cached
 
@@ -13,12 +13,20 @@ from ..tools import (
     coerce_str_to_csv,
     dt_parse_tmpl,
     get_raw_version,
+    lowish,
     parse_ip_address,
     parse_ip_network,
+    strip_right,
 )
+from .tables import tablize, tablize_sqs
 
-CACHE: TTLCache = TTLCache(maxsize=1024, ttl=30)
-SQ_CACHE: TTLCache = TTLCache(maxsize=1024, ttl=30)
+CACHE_MAXSIZE: int = 4096
+CACHE_TTL: int = 30
+CACHE_ADAPTERS: TTLCache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
+CACHE_SQS: TTLCache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
+CACHE_INSTANCES: TTLCache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
+CACHE_CNX_LABELS: TTLCache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
+CACHE_ASSET_LABELS: TTLCache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
 
 
 class WizardParser:
@@ -72,8 +80,7 @@ class WizardParser:
             value=value,
             enum=enum,
             enum_items=enum_items,
-            enum_custom=self._adapter_names(),
-            custom_id="adapter",
+            enum_callback=self.enum_cb_adapter_name,
         )
 
     def value_to_csv_cnx_label(
@@ -83,14 +90,7 @@ class WizardParser:
         enum_items: Optional[List[str]] = None,
     ) -> Tuple[str, str]:
         """Parse a value as a comma separated list of valid connection labels."""
-        aql_value = self.parse_csv(
-            value=value,
-            enum=enum,
-            enum_items=enum_items,
-            enum_custom=self._cnx_labels(),
-            custom_id="connection label",
-        )
-        return aql_value
+        return self.parse_csv(value=value, enum_callback=self.enum_cb_cnx_label)
 
     def value_to_csv_int(
         self,
@@ -145,13 +145,7 @@ class WizardParser:
         enum_items: Optional[List[str]] = None,
     ) -> Tuple[str, str]:
         """Parse a value as a comma separated list of valid asset tags (labels)."""
-        return self.parse_csv(
-            value=value,
-            enum=enum,
-            enum_items=enum_items,
-            enum_custom=self._tags(),
-            custom_id="tag",
-        )
+        return self.parse_csv(value=value, enum_callback=self.enum_cb_asset_tags)
 
     def value_to_dt(
         self,
@@ -242,27 +236,32 @@ class WizardParser:
             value=value,
             enum=enum,
             enum_items=enum_items,
-            enum_custom=self._adapter_names(),
-            custom_id="adapter",
+            enum_callback=self.enum_cb_adapter_name,
         )
         return aql_value, aql_value
 
-    def value_to_str_sq_name(
+    def value_to_str_sq(
         self,
         value: Any,
         enum: Optional[List[str]] = None,
         enum_items: Optional[List[str]] = None,
     ) -> Tuple[str, str]:
-        """Parse a value as a valid name of Saved Query."""
+        """Parse a value as a valid name or UUID of Saved Query."""
         check_type(value=value, exp=str)
         check_empty(value=value)
-        aql_value = self.check_enum(
-            value=value,
-            enum=enum,
-            enum_items=enum_items,
-            enum_custom=self._sq_enum(),
-            custom_id="saved query name",
-        )
+        aql_value = self.check_enum(value=value, enum_callback=self.enum_cb_sq)
+        return aql_value, aql_value
+
+    def value_to_str_data_scope(
+        self,
+        value: Any,
+        enum: Optional[List[str]] = None,
+        enum_items: Optional[List[str]] = None,
+    ) -> Tuple[str, str]:
+        """Parse a value as a valid name or UUID of a Data Scope."""
+        check_type(value=value, exp=str)
+        check_empty(value=value)
+        aql_value = self.check_enum(value=value, enum_callback=self.enum_cb_data_scope)
         return aql_value, aql_value
 
     def value_to_str_cnx_label(
@@ -274,13 +273,7 @@ class WizardParser:
         """Parse a value as a valid connection label."""
         check_type(value=value, exp=str)
         check_empty(value=value)
-        aql_value = self.check_enum(
-            value=value,
-            enum=enum,
-            enum_items=enum_items,
-            enum_custom=self._cnx_labels(),
-            custom_id="connection label",
-        )
+        aql_value = self.check_enum(value=value, enum_callback=self.enum_cb_cnx_label)
         return aql_value, aql_value
 
     def value_to_str_escaped_regex(
@@ -304,13 +297,7 @@ class WizardParser:
         """Parse a value as a valid asset tag (label)."""
         check_type(value=value, exp=str)
         check_empty(value=value)
-        aql_value = self.check_enum(
-            value=value,
-            enum=enum,
-            enum_items=enum_items,
-            enum_custom=self._tags(),
-            custom_id="tag",
-        )
+        aql_value = self.check_enum(value=value, enum_callback=self.enum_cb_asset_tags)
         return aql_value, aql_value
 
     def value_to_str_subnet(
@@ -330,8 +317,7 @@ class WizardParser:
         join_tmpl: str = '"{}"',
         enum: Optional[List[str]] = None,
         enum_items: Optional[List[str]] = None,
-        enum_custom: Optional[List[Union[int, str]]] = None,
-        custom_id: Optional[str] = None,
+        enum_callback: Optional[Callable] = None,
     ) -> Tuple[str, str]:
         """Parse a comma separated string.
 
@@ -341,27 +327,22 @@ class WizardParser:
             join_tmpl: template to use when joining the values for the SQL value
             enum: valid values allowed for the field this value is intended for
             enum_items: more valid values allowed for the field this value is intended for
-            enum_custom: custom values allowed for the field this value is intended for
-            custom_id: identifier for source of enum_custom
+            enum_callback: custom values allowed for the field this value is intended for
         """
-        items = coerce_str_to_csv(value=value)
 
-        new_items = []
-        for idx, item in enumerate(items):
-            item_num = idx + 1
+        def parse_item(item, idx):
             try:
-                new_items.append(
-                    self.check_enum(
-                        value=converter(item) if converter else item,
-                        enum=enum,
-                        enum_items=enum_items,
-                        enum_custom=enum_custom,
-                        custom_id=custom_id,
-                    )
+                return self.check_enum(
+                    value=converter(item) if converter else item,
+                    enum=enum,
+                    enum_items=enum_items,
+                    enum_callback=enum_callback,
                 )
             except Exception as exc:
-                raise WizardError(f"Error in item #{item_num} of {len(items)}: {exc}")
+                raise WizardError(f"Error in item #{idx + 1} of {len(items)} from {value!r}: {exc}")
 
+        items = coerce_str_to_csv(value=value)
+        new_items = [parse_item(item=item, idx=idx) for idx, item in enumerate(items)]
         aql_value = ", ".join([join_tmpl.format(x) for x in new_items])
         value = ",".join([str(x) for x in new_items])
         return aql_value, value
@@ -371,8 +352,7 @@ class WizardParser:
         value: Union[int, str],
         enum: Optional[List[str]] = None,
         enum_items: Optional[List[str]] = None,
-        enum_custom: Optional[Union[List[str], Dict[str, str]]] = None,
-        custom_id: Optional[str] = None,
+        enum_callback: Optional[Callable] = None,
     ) -> Union[int, str]:
         """Check that the value is a valid option of enums.
 
@@ -380,63 +360,160 @@ class WizardParser:
             value: value to check
             enum: valid values allowed for the field this value is intended for
             enum_items: more valid values allowed for the field this value is intended for
-            enum_custom: custom values allowed for the field this value is intended for
-            custom_id: identifier for source of enum_custom
+            enum_callback: custom values allowed for the field this value is intended for
         """
-        if enum_custom is not None and not enum_custom:
-            raise WizardError(f"No {custom_id}s exist, can not query for {custom_id} {value!r}")
+        if callable(enum_callback):
+            return enum_callback(value=value)
 
-        enum = enum or enum_items or enum_custom
+        if enum is not None:
+            enum_use = enum
+        elif enum_items is not None:
+            enum_use = enum_items
+        else:
+            enum_use = None
 
-        if not enum:
-            return value
+        value_check = lowish(value)
 
-        if isinstance(enum, (list, tuple)):
-            for item in enum:
-                item_check = item.lower() if isinstance(item, str) else item
-                value_check = value.lower() if isinstance(value, str) else value
-                if item_check == value_check:
-                    return item
+        if enum_use:
+            if isinstance(enum_use, (list, tuple)):
+                for item in enum_use:
+                    if value_check == lowish(item):
+                        return item
 
-            valid = "\n - " + "\n - ".join([str(x) for x in enum])
-            raise WizardError(f"invalid choice {value!r}, valid choices:{valid}")
+                valid = "\n - " + "\n - ".join([str(x) for x in enum_use])
+                raise WizardError(f"invalid choice {value!r}, valid choices:{valid}")
 
-        elif isinstance(enum, dict):
-            for item, item_value in enum.items():
-                item_check = item.lower() if isinstance(item, str) else item
-                value_check = value.lower() if isinstance(value, str) else value
-                if item_check == value_check:
-                    return item_value
+            if isinstance(enum_use, dict):
+                for item, item_value in enum_use.items():
+                    if value_check in lowish([item, item_value]):
+                        return item_value
 
-            valid = "\n - " + "\n - ".join([str(x) for x in enum])
-            raise WizardError(f"invalid choice {value!r}, valid choices:{valid}")
+                valid = "\n - " + "\n - ".join([str(x) for x in enum_use])
+                raise WizardError(f"invalid choice {value!r}, valid choices:{valid}")
 
-    def _tags(self) -> List[str]:
+            raise WizardError(f"Unexpected enum type {type(enum_use)}: {enum_use!r}")
+
+        return value
+
+    def enum_cb_sq(self, value: Any) -> str:
+        """Pass."""
+        data = self.get_sqs()
+        value_check = lowish(value)
+
+        for item in data:
+            if value_check in lowish([item.name, item.uuid]):
+                return item.uuid
+
+        err = f"No Saved Query found with name or UUID of {value!r} out of {len(data)} items"
+        err_table = tablize_sqs(data=data, err=err)
+        raise WizardError(err_table)
+
+    def enum_cb_cnx_label(self, value: Any) -> str:
+        """Pass."""
+        data = self.get_cnx_labels()
+        instances = self.get_instances()
+        value_check = lowish(value)
+        valids = []
+
+        for item in data:
+            label = "unknown"
+            adapter = "unknown"
+            node_id = "unknown"
+            node_name = "unknown"
+
+            if isinstance(item, dict):
+                label = item.get("label", "unknown")
+                adapter = item.get("plugin_name", "unknown")
+                node_id = item.get("node_id", "unknown")
+
+            for instance in instances:
+                if node_id == instance.id:
+                    node_name = instance.name
+                    break
+
+            adapter = strip_right(obj=adapter, fix="_adapter")
+            valid = {"Label": label, "Adapter": adapter, "Node": node_name}
+            valids.append(valid)
+
+            if value_check == lowish(label):
+                return label
+
+        err = f"No Connection Label found with name of {value!r} out of {len(valids)} items"
+        err_table = tablize(value=valids, err=err)
+        raise WizardError(err_table)
+
+    def enum_cb_asset_tags(self, value: Any) -> str:
+        """Pass."""
+        data = self.get_asset_tags()
+        value_check = lowish(value)
+        valids = []
+
+        for item in data:
+            valid = {"Tag": item}
+            valids.append(valid)
+            if value_check == lowish(item):
+                return item
+
+        err = f"No Asset Tag found with value of {value!r} out of {len(valids)} items"
+        err_table = tablize(value=valids, err=err)
+        raise WizardError(err_table)
+
+    def enum_cb_adapter_name(self, value: Any) -> str:
+        """Pass."""
+        data = self.get_adapters()
+        value_check = lowish(value)
+        valids = []
+
+        for item in data:
+            clients = []
+            name = "unknown"
+            name_raw = "unknown"
+            title = "unknown"
+
+            if isinstance(item, dict):
+                clients = item.get("clients") or []
+                name = item.get("name")
+                name_raw = item.get("name_raw")
+                title = item.get("title")
+
+            cnx_count = len(clients)
+
+            if cnx_count:
+                valid = {"Adapter Title": title, "Adapter Name": name, "Connections": cnx_count}
+                valids.append(valid)
+                if value_check in lowish([name, name_raw, title]):
+                    return name_raw
+
+        err = f"No Adapter with connections found with name of {value!r} out of {len(valids)} items"
+        err_table = tablize(value=valids, err=err)
+        raise WizardError(err_table)
+
+    def enum_cb_data_scope(self, value: Any) -> str:
+        """Pass."""
+        value = self.apiobj.data_scopes.get(value=value)
+        return value.uuid
+
+    @cached(cache=CACHE_ADAPTERS)
+    def get_adapters(self) -> List[dict]:
+        """Get all known adapters."""
+        return list(self.apiobj.adapters._get_basic().adapters.values())
+
+    @cached(cache=CACHE_CNX_LABELS)
+    def get_cnx_labels(self) -> List[dict]:
+        """Get all known adapter connection labels."""
+        return self.apiobj.adapters._get_labels().labels
+
+    @cached(cache=CACHE_INSTANCES)
+    def get_instances(self) -> List[object]:
+        """Get all known instances/nodes."""
+        return self.apiobj.instances._get()
+
+    @cached(cache=CACHE_SQS)
+    def get_sqs(self) -> List[object]:
+        """Get all Saved Query objects for this asset type."""
+        return self.apiobj.saved_query.get(as_dataclass=True)
+
+    @cached(cache=CACHE_ASSET_LABELS)
+    def get_asset_tags(self) -> List[str]:
         """Get all known tags (labels) of this asset type."""
         return self.apiobj.labels.get()
-
-    @cached(cache=CACHE)
-    def _adapters(self) -> List[dict]:
-        """Get all known adapters."""
-        return self.apiobj.adapters.get()
-
-    def _adapter_names(self) -> Dict[str, str]:
-        """Get all known adapter names."""
-        return {x["name"]: x["name_raw"] for x in self._adapters() if x["cnx_count_total"]}
-
-    def _cnx_labels(self) -> List[str]:
-        """Get all known adapter connection labels."""
-        return self.apiobj.adapters._get_labels().label_values
-
-    @cached(cache=SQ_CACHE)
-    def _sqs(self) -> List[dict]:
-        """Get all Saved Query objects for this asset type."""
-        return self.apiobj.saved_query.get()
-
-    def _sq_enum(self) -> Dict[str, str]:
-        """Get all known saved query name -> ID mappings."""
-        ret = {}
-        for sq in self._sqs():
-            ret[sq["name"]] = sq["id"]
-            ret[sq["uuid"]] = sq["id"]
-        return ret

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -1485,3 +1485,10 @@ def int_days_map(value: Union[str, List[Union[str, int]]], names: bool = False) 
         ret = [str(k) for k, v in DAYS_MAP.items() if k in ret]
 
     return ret
+
+
+def lowish(value: Any) -> Any:
+    """Pass."""
+    if isinstance(value, (list, tuple)):
+        return [lowish(x) for x in value]
+    return value.lower() if isinstance(value, str) else value


### PR DESCRIPTION
# Query Wizard
- fixed error when using is_ipv4 and is_ipv6 operators, i.e.
  ```
  simple public_ips is_ipv4
  simple public_ips is_ipv6
  ```
- Saved query supports using name or UUID, i.e.
  ```
  simple sq equals Name Of Saved Query
  simple sq equals UUID_OF_SQ
  ```
- Added support for specifying data scopes, i.e.:
  ```
  simple data_scope equals Name Of Data Scope
  simple data_scope equals UUID_OF_DATA_SCOPE
  ```
- Adapter name supports using short internal name, full internal name, or title, ie.e:
  ```
  # short internal name
  simple adapters equals aws
  # full internal name
  simple adapters equals aws_adapter
  # title
  simple adapters equals tanium asset
  ```
- reworked custom enums into callbacks
- added better caching controls

# AXONSHELL
- fixed output formatting of "Exporting to ..."