### PR TITLE
4.40.2

### DIFF
--- a/axonius_api_client/api/adapters/adapters.py
+++ b/axonius_api_client/api/adapters/adapters.py
@@ -223,9 +223,8 @@ class Adapters(ModelMixins):
             absolute_date_start=absolute_date_start,
             absolute_date_end=absolute_date_end,
         )
-        purpose = "Get Adapter Fetch History Events"
         with PagingState(
-            purpose=purpose,
+            purpose="Get Adapter Fetch History Events",
             page_sleep=page_sleep,
             page_size=page_size,
             row_start=row_start,

--- a/axonius_api_client/api/adapters/adapters.py
+++ b/axonius_api_client/api/adapters/adapters.py
@@ -6,6 +6,7 @@ from typing import Generator, List, Optional, Union
 
 from cachetools import TTLCache, cached
 
+from ...constants.general import OPT_STR_RE_LISTY
 from ...exceptions import ApiError, NotFoundError  # , StopFetch
 from ...parsers.config import config_build, config_unchanged, config_unknown
 from ...parsers.tables import tablize_adapters
@@ -157,17 +158,25 @@ class Adapters(ModelMixins):
         return self._get_fetch_history_filters()
 
     def get_fetch_history(self, generator: bool = False, **kwargs) -> Union[HIST_GEN, HIST_LIST]:
-        """Pass."""
+        """Get adapter fetch history.
+
+        Args:
+            generator (bool, optional): Return a generator or a list
+            **kwargs: passed to :meth:`get_fetch_history_generator`
+
+        Returns:
+            Union[HIST_GEN, HIST_LIST]: Generator or list of history event models
+        """
         gen = self.get_fetch_history_generator(**kwargs)
         return gen if generator else list(gen)
 
     def get_fetch_history_generator(
         self,
-        adapters: Optional[List[str]] = None,
-        connection_labels: Optional[List[str]] = None,
-        clients: Optional[List[str]] = None,
-        instances: Optional[List[str]] = None,
-        statuses: Optional[List[str]] = None,
+        adapters: OPT_STR_RE_LISTY = None,
+        connection_labels: OPT_STR_RE_LISTY = None,
+        clients: OPT_STR_RE_LISTY = None,
+        instances: OPT_STR_RE_LISTY = None,
+        statuses: OPT_STR_RE_LISTY = None,
         exclude_realtime: bool = False,
         relative_unit_type: UnitTypes = UnitTypes.get_default(),
         relative_unit_count: Optional[int] = None,
@@ -175,6 +184,8 @@ class Adapters(ModelMixins):
         absolute_date_end: Optional[datetime.datetime] = None,
         sort_attribute: Optional[str] = None,
         sort_descending: bool = False,
+        search: Optional[str] = None,
+        filter: Optional[str] = None,
         page_sleep: int = PagingState.page_sleep,
         page_size: int = PagingState.page_size,
         row_start: int = PagingState.row_start,
@@ -183,7 +194,39 @@ class Adapters(ModelMixins):
         history_filters: Optional[AdapterFetchHistoryFilters] = None,
         request_obj: Optional[AdapterFetchHistoryRequest] = None,
     ) -> HIST_GEN:
-        """Get adapter fetch history."""
+        """Get adapter fetch history.
+
+        Notes:
+            Use ~ prefix for regex in adapters, connection_labels, clients, instances, statuses
+
+        Args:
+            adapters (OPT_STR_RE_LISTY, optional): Filter for records with matching adapters
+            connection_labels (OPT_STR_RE_LISTY, optional): Filter for records with connection
+                labels
+            clients (OPT_STR_RE_LISTY, optional): Filter for records with matching client ids
+            instances (OPT_STR_RE_LISTY, optional): Filter for records with matching instances
+            statuses (OPT_STR_RE_LISTY, optional): Filter for records with matching statuses
+            exclude_realtime (bool, optional): Exclude records for realtime adapters
+            relative_unit_type (UnitTypes, optional): Type of unit to use when supplying
+                relative_unit_count
+            relative_unit_count (Optional[int], optional): Filter records for the past N units of
+                relative_unit_type
+            absolute_date_start (Optional[datetime.datetime], optional): Filter records that are
+                after this date. (overrides relative values)
+            absolute_date_end (Optional[datetime.datetime], optional): Filter records that are
+                before this date. (defaults to now if start but no end)
+            sort_attribute (Optional[str], optional): Sort records based on this attribute
+            sort_descending (bool, optional): Sort sort_attribute descending or ascending
+            page_sleep (int, optional): Sleep N seconds between pages
+            page_size (int, optional): Get N records per page
+            row_start (int, optional): Start at row N
+            row_stop (Optional[int], optional): Stop at row N
+            log_level (Union[int, str], optional): log level to use for paging
+            history_filters (Optional[AdapterFetchHistoryFilters], optional): response
+                from :meth:`get_fetch_history_filters` (will be fetched if not supplied)
+            request_obj (Optional[AdapterFetchHistoryRequest], optional): Request object to use
+                for options
+        """
         if not isinstance(history_filters, AdapterFetchHistoryFilters):
             history_filters = self.get_fetch_history_filters()
 
@@ -215,14 +258,24 @@ class Adapters(ModelMixins):
             value_type="statuses",
             value=statuses,
         )
-        request_obj.set_sort(value=sort_attribute, descending=sort_descending)
-        request_obj.set_exclude_realtime(value=exclude_realtime)
+        request_obj.set_sort(
+            value=sort_attribute,
+            descending=sort_descending,
+        )
+        request_obj.set_exclude_realtime(
+            value=exclude_realtime,
+        )
         request_obj.set_time_range(
             relative_unit_type=relative_unit_type,
             relative_unit_count=relative_unit_count,
             absolute_date_start=absolute_date_start,
             absolute_date_end=absolute_date_end,
         )
+        request_obj.set_search_filter(
+            search=search,
+            filter=filter,
+        )
+
         with PagingState(
             purpose="Get Adapter Fetch History Events",
             page_sleep=page_sleep,

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -151,7 +151,16 @@ class SavedQueries(ApiEndpointGroup):
     )
     # PBUG: response not properly modeled
 
-    get_history: ApiEndpoint = ApiEndpoint(
+    get_tags: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/{asset_type}/views/tags",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.ListValueSchema,
+        response_model_cls=json_api.generic.ListValue,
+    )
+
+    get_query_history: ApiEndpoint = ApiEndpoint(
         method="get",
         path="api/queries/history",
         request_schema_cls=json_api.saved_queries.QueryHistoryRequestSchema,

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -151,6 +151,16 @@ class SavedQueries(ApiEndpointGroup):
     )
     # PBUG: response not properly modeled
 
+    get_history: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/queries/history",
+        request_schema_cls=json_api.saved_queries.QueryHistoryRequestSchema,
+        request_model_cls=json_api.saved_queries.QueryHistoryRequest,
+        response_schema_cls=None,
+        response_model_cls=None,
+    )
+    # PBUG: response not properly modeled
+
     create: ApiEndpoint = ApiEndpoint(
         method="post",
         path="api/V4.0/{asset_type}/views",

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -156,10 +156,28 @@ class SavedQueries(ApiEndpointGroup):
         path="api/queries/history",
         request_schema_cls=json_api.saved_queries.QueryHistoryRequestSchema,
         request_model_cls=json_api.saved_queries.QueryHistoryRequest,
-        response_schema_cls=None,
-        response_model_cls=None,
+        response_schema_cls=json_api.saved_queries.QueryHistorySchema,
+        response_model_cls=json_api.saved_queries.QueryHistory,
     )
     # PBUG: response not properly modeled
+
+    get_run_by: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="/api/queries/history/run_by_options",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.ListValueSchema,
+        response_model_cls=json_api.generic.ListValue,
+    )
+
+    get_run_from: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/queries/history/run_from_options",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=json_api.generic.ListValueSchema,
+        response_model_cls=json_api.generic.ListValue,
+    )
 
     create: ApiEndpoint = ApiEndpoint(
         method="post",

--- a/axonius_api_client/api/assets/asset_mixin.py
+++ b/axonius_api_client/api/assets/asset_mixin.py
@@ -8,7 +8,7 @@ import cachetools
 
 from ...constants.api import DEFAULT_CALLBACKS_CLS, MAX_PAGE_SIZE, PAGE_SIZE
 from ...exceptions import ApiError, NotFoundError, ResponseNotOk, StopFetch
-from ...tools import dt_now, dt_now_file, json_dump, listify
+from ...tools import dt_now, dt_now_file, get_subcls, json_dump, listify
 from .. import json_api
 from ..api_endpoints import ApiEndpoints
 from ..asset_callbacks.tools import get_callbacks_cls
@@ -48,6 +48,16 @@ class AssetMixin(ModelMixins):
     """
 
     ASSET_TYPE: str = ""
+
+    @classmethod
+    def asset_types(cls) -> List[str]:
+        """Pass."""
+        return [x.ASSET_TYPE for x in cls.asset_modules()]
+
+    @classmethod
+    def asset_modules(cls) -> List["AssetMixin"]:
+        """Pass."""
+        return get_subcls(AssetMixin)
 
     def count(
         self,

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -7,6 +7,7 @@ from typing import Generator, List, Optional, Union
 from cachetools import TTLCache, cached
 
 from ...constants.api import AS_DATACLASS, MAX_PAGE_SIZE
+from ...constants.general import OPT_STR_RE_LISTY
 from ...exceptions import (
     AlreadyExists,
     ApiError,
@@ -567,15 +568,17 @@ class SavedQuery(ChildMixins):
 
     def get_query_history_generator(
         self,
-        run_by: Optional[List[str]] = None,
-        run_from: Optional[List[str]] = None,
-        tags: Optional[List[str]] = None,
-        modules: Optional[List[str]] = None,
+        run_by: OPT_STR_RE_LISTY = None,
+        run_from: OPT_STR_RE_LISTY = None,
+        tags: OPT_STR_RE_LISTY = None,
+        modules: OPT_STR_RE_LISTY = None,
         name_term: Optional[str] = None,
         date_start: Optional[datetime.datetime] = None,
         date_end: Optional[datetime.datetime] = None,
         sort_attribute: Optional[str] = None,
         sort_descending: bool = False,
+        search: Optional[str] = None,
+        filter: Optional[str] = None,
         page_sleep: int = PagingState.page_sleep,
         page_size: int = PagingState.page_size,
         row_start: int = PagingState.row_start,
@@ -584,8 +587,6 @@ class SavedQuery(ChildMixins):
         run_by_values: Optional[List[str]] = None,
         run_from_values: Optional[List[str]] = None,
         request_obj: Optional[QueryHistoryRequest] = None,
-        search: Optional[str] = None,
-        filter: Optional[str] = None,
     ) -> HIST_LIST:
         """Pass."""
         if not isinstance(request_obj, QueryHistoryRequest):
@@ -628,7 +629,6 @@ class SavedQuery(ChildMixins):
             search=search,
             filter=filter,
         )
-
         with PagingState(
             purpose="Get Query History Events",
             page_sleep=page_sleep,

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -562,7 +562,15 @@ class SavedQuery(ChildMixins):
         return self._get_query_history_run_from().value
 
     def get_query_history(self, generator: bool = False, **kwargs) -> Union[HIST_GEN, HIST_LIST]:
-        """Pass."""
+        """Get query history.
+
+        Args:
+            generator (bool, optional): Return a generator or a list
+            **kwargs: passed to :meth:`get_fetch_history_generator`
+
+        Returns:
+            Union[HIST_GEN, HIST_LIST]: Generator or list of query event models
+        """
         gen = self.get_query_history_generator(**kwargs)
         return gen if generator else list(gen)
 
@@ -588,7 +596,34 @@ class SavedQuery(ChildMixins):
         run_from_values: Optional[List[str]] = None,
         request_obj: Optional[QueryHistoryRequest] = None,
     ) -> HIST_LIST:
-        """Pass."""
+        """Get query history.
+
+        Args:
+            run_by (OPT_STR_RE_LISTY, optional): Filter records run by users
+            run_from (OPT_STR_RE_LISTY, optional): Filter records run from api/gui
+            tags (OPT_STR_RE_LISTY, optional): Filter records by SQ tags
+            modules (OPT_STR_RE_LISTY, optional): Filter records by asset type
+                (defaults to parent asset type)
+            name_term (Optional[str], optional): Filter records by SQ name pattern
+            date_start (Optional[datetime.datetime], optional): Filter records after this date
+            date_end (Optional[datetime.datetime], optional): Filter records before this date
+                (will default to now if date_start supplied and no date_end)
+            sort_attribute (Optional[str], optional): Sort records based on this attribute
+            sort_descending (bool, optional): Sort records descending or ascending
+            search (Optional[str], optional): AQL search value to filter records
+            filter (Optional[str], optional): AQL to filter records
+            page_sleep (int, optional): Sleep N seconds between pages
+            page_size (int, optional): Get N records per page
+            row_start (int, optional): Start at row N
+            row_stop (Optional[int], optional): Stop at row N
+            log_level (Union[int, str], optional): log level to use for paging
+            run_by_values (Optional[List[str]], optional): Output from
+                :meth:`get_query_history_run_by` (will be fetched if not supplied)
+            run_from_values (Optional[List[str]], optional): Output from
+                :meth:`get_query_history_run_from` (will be fetched if not supplied)
+            request_obj (Optional[QueryHistoryRequest], optional):  Request object to use
+                for options
+        """
         if not isinstance(request_obj, QueryHistoryRequest):
             request_obj = QueryHistoryRequest()
 

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 """API for working with saved queries for assets."""
+import datetime
 import warnings
 from typing import Generator, List, Optional, Union
+
+from cachetools import TTLCache, cached
 
 from ...constants.api import AS_DATACLASS, MAX_PAGE_SIZE
 from ...exceptions import (
@@ -22,9 +25,14 @@ MODEL = json_api.saved_queries.SavedQuery
 MODEL_GET = json_api.saved_queries.SavedQueryGet
 MODEL_FOLDER = json_api.saved_queries.Folder
 MODEL_HIST = QueryHistory
+HIST_GEN = Generator[QueryHistory, None, None]
+HIST_LIST = List[QueryHistory]
 BOTH = Union[dict, MODEL]
 MULTI = Union[str, BOTH]
 GEN = Generator[BOTH, None, None]
+CACHE_TAGS = TTLCache(maxsize=1024, ttl=60)
+CACHE_RUN_BY = TTLCache(maxsize=1024, ttl=60)
+CACHE_RUN_FROM = TTLCache(maxsize=1024, ttl=60)
 
 
 class SavedQuery(ChildMixins):
@@ -519,7 +527,7 @@ class SavedQuery(ChildMixins):
             raise SavedQueryTagsNotFoundError(value=value, valid=valid)
         return found if as_dataclass else [x.to_dict() for x in found]
 
-    def get_tags(self) -> List[str]:
+    def get_tags_slow(self) -> List[str]:
         """Get all tags for saved queries.
 
         Examples:
@@ -536,6 +544,102 @@ class SavedQuery(ChildMixins):
         for sq in self.get(as_dataclass=True):
             tags += [x for x in sq.tags if x not in tags]
         return tags
+
+    @cached(cache=CACHE_TAGS)
+    def get_tags(self) -> List[str]:
+        """Get all tags for saved queries."""
+        return self._get_tags().value
+
+    @cached(cache=CACHE_RUN_BY)
+    def get_query_history_run_by(self) -> List[str]:
+        """Get the valid values for the run_by attribute for getting query history."""
+        return self._get_query_history_run_by().value
+
+    @cached(cache=CACHE_RUN_FROM)
+    def get_query_history_run_from(self) -> List[str]:
+        """Get the valid values for the run_from attribute for getting query history."""
+        return self._get_query_history_run_from().value
+
+    def get_query_history(self, generator: bool = False, **kwargs) -> Union[HIST_GEN, HIST_LIST]:
+        """Pass."""
+        gen = self.get_query_history_generator(**kwargs)
+        return gen if generator else list(gen)
+
+    def get_query_history_generator(
+        self,
+        run_by: Optional[List[str]] = None,
+        run_from: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        modules: Optional[List[str]] = None,
+        name_term: Optional[str] = None,
+        date_start: Optional[datetime.datetime] = None,
+        date_end: Optional[datetime.datetime] = None,
+        sort_attribute: Optional[str] = None,
+        sort_descending: bool = False,
+        page_sleep: int = PagingState.page_sleep,
+        page_size: int = PagingState.page_size,
+        row_start: int = PagingState.row_start,
+        row_stop: Optional[int] = PagingState.row_stop,
+        log_level: Union[int, str] = PagingState.log_level,
+        run_by_values: Optional[List[str]] = None,
+        run_from_values: Optional[List[str]] = None,
+        request_obj: Optional[QueryHistoryRequest] = None,
+        search: Optional[str] = None,
+        filter: Optional[str] = None,
+    ) -> HIST_LIST:
+        """Pass."""
+        if not isinstance(request_obj, QueryHistoryRequest):
+            request_obj = QueryHistoryRequest()
+
+        request_obj.set_list(
+            prop="run_from",
+            values=run_from,
+            enum=run_from_values,
+            enum_callback=self.get_query_history_run_from,
+        )
+        request_obj.set_list(
+            prop="run_by",
+            values=run_by,
+            enum=run_by_values,
+            enum_callback=self.get_query_history_run_by,
+        )
+        request_obj.set_list(
+            prop="tags",
+            values=tags,
+            enum_callback=self.get_tags,
+        )
+        request_obj.set_list(
+            prop="modules",
+            values=modules or self.parent.ASSET_TYPE,
+            enum_callback=self.parent.asset_types,
+        )
+        request_obj.set_date(
+            date_start=date_start,
+            date_end=date_end,
+        )
+        request_obj.set_sort(
+            value=sort_attribute,
+            descending=sort_descending,
+        )
+        request_obj.set_name_term(
+            value=name_term,
+        )
+        request_obj.set_search_filter(
+            search=search,
+            filter=filter,
+        )
+
+        with PagingState(
+            purpose="Get Query History Events",
+            page_sleep=page_sleep,
+            page_size=page_size,
+            row_start=row_start,
+            row_stop=row_stop,
+            log_level=log_level,
+        ) as state:
+            while not state.stop_paging:
+                page = state.page(method=self._get_query_history, request_obj=request_obj)
+                yield from page.rows
 
     def get(self, generator: bool = False, **kwargs) -> Union[GEN, List[BOTH]]:
         """Get all saved queries.
@@ -1086,30 +1190,27 @@ class SavedQuery(ChildMixins):
         except SavedQueryNotFoundError:
             return
 
-    def _get_history(self, request_obj: Optional[QueryHistoryRequest] = None) -> List[MODEL_HIST]:
+    def _get_query_history(self, request_obj: Optional[QueryHistoryRequest] = None) -> HIST_LIST:
         """Pass."""
-        api_endpoint = ApiEndpoints.saved_queries.get_history
+        api_endpoint = ApiEndpoints.saved_queries.get_query_history
         if not request_obj:
             request_obj = QueryHistoryRequest()
         return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
 
-    def _get_run_by(self) -> json_api.generic.ListValueSchema:
+    def _get_query_history_run_by(self) -> json_api.generic.ListValueSchema:
         """Get the valid values for the run_by attribute for getting query history."""
         api_endpoint = ApiEndpoints.saved_queries.get_run_by
         return api_endpoint.perform_request(http=self.auth.http)
 
-    def _get_run_from(self) -> json_api.generic.ListValueSchema:
+    def _get_query_history_run_from(self) -> json_api.generic.ListValueSchema:
         """Get the valid values for the run_from attribute for getting query history."""
         api_endpoint = ApiEndpoints.saved_queries.get_run_from
         return api_endpoint.perform_request(http=self.auth.http)
 
-    def get_values_run_by(self) -> List[str]:
-        """Get the valid values for the run_by attribute for getting query history."""
-        return self._get_run_by().value
-
-    def get_values_run_from(self) -> List[str]:
-        """Get the valid values for the run_from attribute for getting query history."""
-        return self._get_run_from().value
+    def _get_tags(self) -> json_api.generic.ListValueSchema:
+        """Get the valid tags."""
+        api_endpoint = ApiEndpoints.saved_queries.get_tags
+        return api_endpoint.perform_request(http=self.auth.http, asset_type=self.parent.ASSET_TYPE)
 
     # WIP: folders
     '''

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -305,11 +305,12 @@ class SavedQuery(ChildMixins):
                 )
                 warnings.warn(message=msg, category=GuiQueryWizardWarning)
 
+        query = query or ""
         sq.query = query
         sq.query_expr = query
         if isinstance(expressions, list):
             sq.expressions = expressions
-        elif not append:
+        elif not append and query:
             msg = "\n".join(
                 [
                     f"Updating query {query!r} with no expressions",
@@ -1082,6 +1083,11 @@ class SavedQuery(ChildMixins):
             raise AlreadyExists(f"Saved query with name or uuid of {value!r} already exists:\n{sq}")
         except SavedQueryNotFoundError:
             return
+
+    def _get_history(self):
+        """Pass."""
+        api_endpoint = ApiEndpoints.saved_queries.get_history
+        return api_endpoint.perform_request(http=self.auth.http)
 
     # WIP: folders
     '''

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -15,11 +15,13 @@ from ...tools import check_gui_page_size, coerce_bool, echo_ok, echo_warn, listi
 from .. import json_api
 from ..api_endpoints import ApiEndpoints
 from ..json_api.paging_state import LOG_LEVEL_API, PAGE_SIZE, PagingState
+from ..json_api.saved_queries import QueryHistory, QueryHistoryRequest
 from ..mixins import ChildMixins
 
 MODEL = json_api.saved_queries.SavedQuery
 MODEL_GET = json_api.saved_queries.SavedQueryGet
 MODEL_FOLDER = json_api.saved_queries.Folder
+MODEL_HIST = QueryHistory
 BOTH = Union[dict, MODEL]
 MULTI = Union[str, BOTH]
 GEN = Generator[BOTH, None, None]
@@ -1084,10 +1086,30 @@ class SavedQuery(ChildMixins):
         except SavedQueryNotFoundError:
             return
 
-    def _get_history(self):
+    def _get_history(self, request_obj: Optional[QueryHistoryRequest] = None) -> List[MODEL_HIST]:
         """Pass."""
         api_endpoint = ApiEndpoints.saved_queries.get_history
+        if not request_obj:
+            request_obj = QueryHistoryRequest()
+        return api_endpoint.perform_request(http=self.auth.http, request_obj=request_obj)
+
+    def _get_run_by(self) -> json_api.generic.ListValueSchema:
+        """Get the valid values for the run_by attribute for getting query history."""
+        api_endpoint = ApiEndpoints.saved_queries.get_run_by
         return api_endpoint.perform_request(http=self.auth.http)
+
+    def _get_run_from(self) -> json_api.generic.ListValueSchema:
+        """Get the valid values for the run_from attribute for getting query history."""
+        api_endpoint = ApiEndpoints.saved_queries.get_run_from
+        return api_endpoint.perform_request(http=self.auth.http)
+
+    def get_values_run_by(self) -> List[str]:
+        """Get the valid values for the run_by attribute for getting query history."""
+        return self._get_run_by().value
+
+    def get_values_run_from(self) -> List[str]:
+        """Get the valid values for the run_from attribute for getting query history."""
+        return self._get_run_from().value
 
     # WIP: folders
     '''

--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -14,7 +14,7 @@ from ...exceptions import ApiError, NotFoundError
 from ...http import Http
 from ...parsers.config import parse_schema
 from ...parsers.tables import tablize
-from ...tools import coerce_bool, listify, longest_str, strip_right
+from ...tools import coerce_bool, listify, longest_str
 from .base import BaseModel, BaseSchema, BaseSchemaJson
 
 # from .count_operator import CountOperator, CountOperatorSchema
@@ -25,21 +25,6 @@ from .time_range import TimeRange, TimeRangeSchema, UnitTypes
 
 STR_RE = Union[str, Pattern]
 STR_RE_LISTY = Union[STR_RE, List[STR_RE]]
-
-
-def prepend_sort(value: str, descending: bool = False):
-    """Pass."""
-    if isinstance(value, str):
-        if value.startswith("-"):
-            value = value[1:]
-        if descending:
-            value = f"-{value}"
-    return value
-
-
-def get_aname(value: str) -> str:
-    """Pass."""
-    return strip_right(obj=str(value or ""), fix="_adapter")
 
 
 class AdapterFetchHistorySchema(BaseSchemaJson):
@@ -244,7 +229,7 @@ class AdapterFetchHistory(BaseModel):
     @property
     def adapter_name(self) -> str:
         """Pass."""
-        return get_aname(self.adapter["icon"])
+        return self._get_aname(self.adapter["icon"])
 
     @property
     def adapter_name_raw(self) -> str:
@@ -476,7 +461,7 @@ class AdapterFetchHistoryRequest(BaseModel):
         """Pass."""
         if isinstance(value, str) and value:
             value = AdapterFetchHistorySchema.validate_attr(value=value, exc_cls=NotFoundError)
-            value = prepend_sort(value=value, descending=descending)
+            value = self._prepend_sort(value=value, descending=descending)
         else:
             value = None
 
@@ -652,7 +637,7 @@ class AdapterFetchHistoryFilters(BaseModel):
     def adapters(self) -> dict:
         """Pass."""
         return {
-            x["id"]: {"name": get_aname(x["id"]), "name_raw": x["id"], "title": x["name"]}
+            x["id"]: {"name": self._get_aname(x["id"]), "name_raw": x["id"], "title": x["name"]}
             for x in self.adapters_filter
         }
 
@@ -979,7 +964,7 @@ class AdapterNode(BaseModel):
     def __post_init__(self):
         """Pass."""
         self.adapter_name_raw = self.plugin_name
-        self.adapter_name = get_aname(self.plugin_name)
+        self.adapter_name = self._get_aname(self.plugin_name)
 
     @property
     def cnxs(self):
@@ -1167,7 +1152,7 @@ class Adapter(BaseModel):
     def __post_init__(self):
         """Pass."""
         self.adapter_name_raw = self.id
-        self.adapter_name = get_aname(self.id)
+        self.adapter_name = self._get_aname(self.id)
         self.document_meta = self.document_meta.pop(self.id, None)
         """
         document_meta: {}
@@ -1244,7 +1229,7 @@ class AdapterNodeCnx(BaseModel):
     def __post_init__(self):
         """Pass."""
         self.adapter_name_raw = self.adapter_name
-        self.adapter_name = get_aname(self.adapter_name)
+        self.adapter_name = self._get_aname(self.adapter_name)
 
     @property
     def working(self) -> bool:
@@ -1488,7 +1473,7 @@ class AdaptersList(Metadata):
         ret = {}
         for item in items:
             name_raw = item["name"]
-            name = get_aname(name_raw)
+            name = self._get_aname(name_raw)
             item["name_raw"] = name_raw
             item["name"] = name
             ret[name] = item
@@ -1496,7 +1481,7 @@ class AdaptersList(Metadata):
 
     def find_by_name(self, value: str) -> dict:
         """Pass."""
-        find_value = get_aname(value)
+        find_value = self._get_aname(value)
         adapters = self.adapters
         if find_value not in adapters:
             padding = longest_str(list(adapters))
@@ -1711,7 +1696,7 @@ class Cnx(BaseModel):
     def __post_init__(self):
         """Pass."""
         self.adapter_name_raw = self.adapter_name
-        self.adapter_name = get_aname(self.adapter_name)
+        self.adapter_name = self._get_aname(self.adapter_name)
 
     @staticmethod
     def _str_properties() -> List[str]:

--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -366,7 +366,7 @@ class AdapterFetchHistoryRequestSchema(BaseSchemaJson):
     exclude_realtime = SchemaBool(load_default=False, dump_default=False)
     time_range = marshmallow_jsonapi.fields.Nested(TimeRangeSchema)
     page = marshmallow_jsonapi.fields.Nested(PaginationSchema)
-    search = marshmallow_jsonapi.fields.Str(load_default="", dump_default="")
+    search = marshmallow_jsonapi.fields.Str(allow_none=True, load_default="", dump_default="")
     filter = marshmallow_jsonapi.fields.Str(allow_none=True, load_default="", dump_default="")
 
     # total_devices_filter = marshmallow_jsonapi.fields.Nested(CountOperatorSchema)
@@ -486,7 +486,7 @@ class AdapterFetchHistoryRequest(BaseModel):
         if any(is_strs) and not all(is_strs):
             raise ApiError(f"Only search or filter supplied, must supply both: {values}")
         if not all(is_strs):
-            search = None
+            search = ""
             filter = None
         self.search = search
         self.filter = filter

--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -4,12 +4,13 @@ import dataclasses
 import datetime
 import re
 import textwrap
-from typing import ClassVar, List, Optional, Pattern, Type, Union
+from typing import ClassVar, List, Optional, Tuple, Type
 
 import marshmallow
 import marshmallow_jsonapi
 
 from ...constants.adapters import DISCOVERY_NAME, GENERIC_NAME, INGESTION_NAME
+from ...constants.general import STR_RE_LISTY
 from ...exceptions import ApiError, NotFoundError
 from ...http import Http
 from ...parsers.config import parse_schema
@@ -22,9 +23,6 @@ from .custom_fields import SchemaBool, SchemaDatetime, dump_date, get_field_dc_m
 from .generic import Metadata, MetadataSchema
 from .resources import PaginationRequest, PaginationSchema
 from .time_range import TimeRange, TimeRangeSchema, UnitTypes
-
-STR_RE = Union[str, Pattern]
-STR_RE_LISTY = Union[STR_RE, List[STR_RE]]
 
 
 class AdapterFetchHistorySchema(BaseSchemaJson):
@@ -478,6 +476,21 @@ class AdapterFetchHistoryRequest(BaseModel):
 
         self.sort = value
         return value
+
+    def set_search_filter(
+        self, search: Optional[str] = None, filter: Optional[str] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Pass."""
+        values = [search, filter]
+        is_strs = [isinstance(x, str) and x for x in values]
+        if any(is_strs) and not all(is_strs):
+            raise ApiError(f"Only search or filter supplied, must supply both: {values}")
+        if not all(is_strs):
+            search = None
+            filter = None
+        self.search = search
+        self.filter = filter
+        return (search, filter)
 
     def set_filters(
         self,

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -323,11 +323,16 @@ class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
         dumped = json_load(obj=json_dump(obj=self.to_dict()))
         ret = {}
         for k, v in dumped.items():
+            if v is None:
+                continue
+
             if isinstance(v, dict):
                 for a, b in v.items():
                     if isinstance(b, SIMPLE):
                         ret[f"{k}[{a}]"] = b
             elif isinstance(v, SIMPLE):
+                ret[k] = v
+            elif isinstance(v, (list, tuple)) and v and all([isinstance(x, SIMPLE) for x in v]):
                 ret[k] = v
         return ret
 

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -70,6 +70,7 @@ class BaseCommon:
         cls._post_load_attrs(data=loaded, **kwargs)
         return loaded
 
+    @staticmethod
     def _get_aname(value: str) -> str:
         """Pass."""
         return strip_right(obj=str(value or ""), fix="_adapter")
@@ -177,7 +178,7 @@ class BaseSchemaJson(BaseSchema, marshmallow_jsonapi.Schema):
             SchemaError: if data is not a dict
         """
         if not isinstance(data, dict):
-            if isinstance(data, list) and data:
+            if isinstance(data, list):
                 # Fix for endpoints that do not return JSON API structure
                 data = {"data": [{"attributes": x, "type": cls.Meta.type_} for x in data]}
             else:

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -18,6 +18,7 @@ from ...exceptions import (
     SchemaError,
 )
 from ...http import Http
+from ...logs import get_obj_log
 from ...tools import coerce_bool, combo_dicts, json_dump, json_load, listify, strip_right
 
 LOGGER = logging.getLogger(__name__)
@@ -222,6 +223,11 @@ class BaseSchemaJson(BaseSchema, marshmallow_jsonapi.Schema):
 @dataclasses.dataclass
 class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
     """Model base class for holding data."""
+
+    @property
+    def _log(self) -> logging.Logger:
+        """Pass."""
+        return get_obj_log(self)
 
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Get the BaseSchema that should be used to validate the data for this model.

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -18,7 +18,7 @@ from ...exceptions import (
     SchemaError,
 )
 from ...http import Http
-from ...tools import coerce_bool, combo_dicts, json_dump, json_load, listify
+from ...tools import coerce_bool, combo_dicts, json_dump, json_load, listify, strip_right
 
 LOGGER = logging.getLogger(__name__)
 EXTRA_WARN = False
@@ -69,6 +69,20 @@ class BaseCommon:
 
         cls._post_load_attrs(data=loaded, **kwargs)
         return loaded
+
+    def _get_aname(value: str) -> str:
+        """Pass."""
+        return strip_right(obj=str(value or ""), fix="_adapter")
+
+    @staticmethod
+    def _prepend_sort(value: str, descending: bool = False):
+        """Pass."""
+        if isinstance(value, str):
+            if value.startswith("-"):
+                value = value[1:]
+            if descending:
+                value = f"-{value}"
+        return value
 
 
 class BaseSchema(BaseCommon, marshmallow.Schema):

--- a/axonius_api_client/api/json_api/custom_fields.py
+++ b/axonius_api_client/api/json_api/custom_fields.py
@@ -105,6 +105,12 @@ def get_field_dc_mm(mm_field: marshmallow.fields.Field, **kwargs) -> dataclasses
     return dataclasses.field(**kwargs)
 
 
+def get_schema_dc(schema: marshmallow.Schema, key: str, **kwargs) -> dataclasses.Field:
+    """Pass."""
+    kwargs["mm_field"] = schema._declared_fields[key]
+    return get_field_dc_mm(**kwargs)
+
+
 def validator_wrapper(fn: callable) -> callable:
     """Pass."""
 

--- a/axonius_api_client/api/json_api/generic.py
+++ b/axonius_api_client/api/json_api/generic.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Models for API requests & responses."""
 import dataclasses
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 import marshmallow_jsonapi
 
 from ...http import Http
 from .base import BaseModel, BaseSchema, BaseSchemaJson
-from .custom_fields import SchemaBool
+from .custom_fields import SchemaBool, get_schema_dc
 
 
 class MetadataSchema(BaseSchemaJson):
@@ -160,6 +160,34 @@ class StrValue(BaseModel):
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
         return StrValueSchema
+
+
+class ListValueSchema(BaseSchemaJson):
+    """Pass."""
+
+    value = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
+
+    class Meta:
+        """Pass."""
+
+        type_ = "list_value_schema"
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return ListValue
+
+
+@dataclasses.dataclass
+class ListValue(BaseModel):
+    """Pass."""
+
+    value: List[str] = get_schema_dc(schema=ListValueSchema, key="value", default_factory=list)
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return ListValueSchema
 
 
 class DictValueSchema(BaseSchemaJson):

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -91,7 +91,7 @@ class QueryHistoryRequestSchema(BaseSchemaJson):
         dump_default=None,
         validate=QueryHistorySchema.validate_attr,
     )
-    search = marshmallow_jsonapi.fields.Str(load_default="", dump_default="")
+    search = marshmallow_jsonapi.fields.Str(allow_none=True, load_default="", dump_default="")
     filter = marshmallow_jsonapi.fields.Str(allow_none=True, load_default="", dump_default="")
 
     @staticmethod
@@ -700,7 +700,7 @@ class QueryHistoryRequest(BaseModel):
         if any(is_strs) and not all(is_strs):
             raise ApiError(f"Only search or filter supplied, must supply both: {values}")
         if not all(is_strs):
-            search = None
+            search = ""
             filter = None
         self.search = search
         self.filter = filter

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -12,7 +12,7 @@ from ...constants.api import GUI_PAGE_SIZES
 from ...exceptions import ApiAttributeTypeError, ApiError
 from ...tools import coerce_bool, coerce_int, listify
 from .base import BaseModel, BaseSchema, BaseSchemaJson
-from .custom_fields import SchemaBool, SchemaDatetime
+from .custom_fields import SchemaBool, SchemaDatetime, get_field_dc_mm, get_schema_dc
 from .generic import PrivateRequest, PrivateRequestSchema
 from .resources import PaginationRequest, ResourcesGet, ResourcesGetSchema
 
@@ -35,6 +35,63 @@ class SavedQueryGetSchema(ResourcesGetSchema):
         """Pass."""
 
         type_ = "request_views_schema"
+
+
+class QueryHistoryRequestSchema(ResourcesGetSchema):
+    """Pass."""
+
+    folder_id = marshmallow_jsonapi.fields.Str(load_default="", dump_default="")
+
+    run_by = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
+    run_from = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
+    modules = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
+    tags = marshmallow_jsonapi.fields.List(marshmallow_jsonapi.fields.Str())
+    saved_query_name_term = marshmallow_jsonapi.fields.Str(allow_none=True)
+    date_from = SchemaDatetime(allow_none=True)
+    date_to = SchemaDatetime(allow_none=True)
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return QueryHistoryRequest
+
+    class Meta:
+        """Pass."""
+
+        type_ = "entities_queries_history_request_schema"
+
+
+class QueryHistorySchema(BaseSchemaJson):
+    """Pass."""
+
+    query_id = marshmallow_jsonapi.fields.Str(allow_none=False)
+    saved_query_name = marshmallow_jsonapi.fields.Str(
+        load_default=None, dump_default=None, allow_none=True
+    )
+    saved_query_tags = marshmallow.fields.List(marshmallow_jsonapi.fields.Str())
+    start_time = SchemaDatetime(allow_none=True)
+    end_time = SchemaDatetime(allow_none=True)
+    duration = marshmallow_jsonapi.fields.Str(load_default=None, dump_default=None, allow_none=True)
+    run_by = marshmallow_jsonapi.fields.Str(load_default=None, dump_default=None, allow_none=True)
+    run_from = marshmallow_jsonapi.fields.Str(load_default=None, dump_default=None, allow_none=True)
+    execution_source = marshmallow_jsonapi.fields.Dict(
+        load_default=None, dump_default=None, allow_none=True
+    )
+    status = marshmallow_jsonapi.fields.Str(load_default=None, dump_default=None, allow_none=True)
+    module = marshmallow_jsonapi.fields.Str(load_default=None, dump_default=None, allow_none=True)
+    results_count = marshmallow.fields.Integer(
+        load_default=None, dump_default=None, allow_none=True
+    )
+
+    class Meta:
+        """Pass."""
+
+        type_ = "entities_queries_history_response_schema"
+
+    @staticmethod
+    def get_model_cls() -> type:
+        """Pass."""
+        return QueryHistory
 
 
 class SavedQuerySchema(BaseSchemaJson):
@@ -466,6 +523,88 @@ class SavedQueryGet(ResourcesGet):
     def get_schema_cls() -> Optional[Type[BaseSchema]]:
         """Pass."""
         return SavedQueryGetSchema
+
+
+@dataclasses.dataclass
+class QueryHistoryRequest(ResourcesGet):
+    """Pass."""
+
+    run_by: Optional[List[str]] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["run_by"],
+        default_factory=list,
+    )
+    run_from: Optional[List[str]] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["run_from"],
+        default_factory=list,
+    )
+    modules: Optional[List[str]] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["modules"],
+        default_factory=list,
+    )
+    tags: Optional[List[str]] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["tags"],
+        default_factory=list,
+    )
+    saved_query_name_term: Optional[str] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["saved_query_name_term"],
+        default=None,
+    )
+    date_from: Optional[datetime.datetime] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["date_from"],
+        default=None,
+    )
+    date_to: Optional[datetime.datetime] = get_field_dc_mm(
+        mm_field=QueryHistoryRequestSchema._declared_fields["date_to"],
+        default=None,
+    )
+
+    def __post_init__(self):
+        """Pass."""
+        self.run_by = self.run_by or []
+        self.run_from = self.run_from or []
+        self.modules = self.modules or []
+        self.tags = self.tags or []
+        self.page = self.page if self.page else PaginationRequest()
+
+    @staticmethod
+    def get_schema_cls() -> Optional[Type[BaseSchema]]:
+        """Pass."""
+        return QueryHistoryRequestSchema
+
+
+@dataclasses.dataclass
+class QueryHistory(BaseModel):
+    """Pass."""
+
+    query_id: str = get_schema_dc(schema=QueryHistorySchema, key="query_id")
+    saved_query_name: Optional[str] = get_schema_dc(
+        schema=QueryHistorySchema, key="saved_query_name", default=None
+    )
+    saved_query_tags: Optional[List[str]] = get_schema_dc(
+        schema=QueryHistorySchema, key="saved_query_tags", default=None
+    )
+    start_time: Optional[datetime.datetime] = get_schema_dc(
+        schema=QueryHistorySchema, key="start_time", default=None
+    )
+    end_time: Optional[datetime.datetime] = get_schema_dc(
+        schema=QueryHistorySchema, key="end_time", default=None
+    )
+    duration: Optional[str] = get_schema_dc(schema=QueryHistorySchema, key="duration", default=None)
+    run_by: Optional[str] = get_schema_dc(schema=QueryHistorySchema, key="run_by", default=None)
+    run_from: Optional[str] = get_schema_dc(schema=QueryHistorySchema, key="run_from", default=None)
+    execution_source: Optional[dict] = get_schema_dc(
+        schema=QueryHistorySchema, key="execution_source", default=None
+    )
+    status: Optional[str] = get_schema_dc(schema=QueryHistorySchema, key="status", default=None)
+    module: Optional[str] = get_schema_dc(schema=QueryHistorySchema, key="module", default=None)
+    results_count: Optional[int] = get_schema_dc(
+        schema=QueryHistorySchema, key="results_count", default=None
+    )
+
+    @staticmethod
+    def get_schema_cls():
+        """Pass."""
+        return QueryHistorySchema
 
 
 # WIP: folders

--- a/axonius_api_client/cli/grp_adapters/grp_common.py
+++ b/axonius_api_client/cli/grp_adapters/grp_common.py
@@ -1,23 +1,8 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-from ...api.json_api.adapters import AdapterFetchHistory
 from ...constants.adapters import CONFIG_TYPES
-from ...parsers.tables import tablize
-from ...tools import csv_writer, json_dump
+from ...tools import json_dump
 from ..context import click
-
-
-def export_to_tablize(data, **kwargs):
-    """Pass."""
-    items = [x.to_tablize() for x in data] if isinstance(data, list) else [data.to_tablize()]
-    return tablize(items)
-
-
-def export_csv(data, **kwargs):
-    """Pass."""
-    rows = [x.to_csv() for x in data]
-    columns = AdapterFetchHistory._props_csv()
-    return csv_writer(rows=rows, columns=columns)
 
 
 def export_json_full(data, **kwargs):

--- a/axonius_api_client/cli/options.py
+++ b/axonius_api_client/cli/options.py
@@ -10,6 +10,23 @@ from . import context
 from .helps import HELPSTRS
 
 
+def build_filter_opt(value_type: str):
+    """Pass."""
+    short_opt = "".join([x[0] for x in value_type.split("_")])
+    long_opt = value_type.replace("_", "-")
+    camel = " ".join(x.title() for x in value_type.split("_"))
+    return click.option(
+        f"--filter-{long_opt}",
+        f"-f{short_opt}",
+        f"{value_type}",
+        help=f"Filter for records with matching {camel} (~ prefix for regex!) (multiple)",
+        multiple=True,
+        show_envvar=True,
+        show_default=True,
+        required=False,
+    )
+
+
 def add_options(options):
     """Pass."""
 

--- a/axonius_api_client/constants/adapters.py
+++ b/axonius_api_client/constants/adapters.py
@@ -52,6 +52,8 @@ GENERIC_NAME: str = "AdapterBase"
 DISCOVERY_NAME: str = "DiscoverySchema"
 """name of discover adapter advanced settings in adapter schemas"""
 
+INGESTION_NAME: str = "IngestionRulesSchema"
+
 CONFIG_TYPES: List[str] = ["generic", "specific", "discovery"]
 """valid names of types of adapter advanced settings"""
 

--- a/axonius_api_client/constants/general.py
+++ b/axonius_api_client/constants/general.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Constants for general use."""
 import sys
-from typing import List, Tuple, Type, Union
+from typing import List, Optional, Pattern, Tuple, Type, Union
 
 URL_STARTS: List[str] = ["https://", "http://"]
 
@@ -40,6 +40,11 @@ COMPLEX: Tuple[Type] = (dict, list, tuple)
 
 SIMPLE: Tuple[Type] = (str, int, bool, float)
 """types that are considered as simple"""
+
+OPT_LIST_STR = Optional[Union[str, List[str]]]
+STR_RE = Union[str, Pattern]
+STR_RE_LISTY = Union[STR_RE, List[STR_RE]]
+OPT_STR_RE_LISTY = Optional[STR_RE_LISTY]
 
 JSON_TYPES = Union[int, str, float, bool, dict, list, tuple, None]
 

--- a/axonius_api_client/tests/tests_api/tests_adapters/test_adapters.py
+++ b/axonius_api_client/tests/tests_api/tests_adapters/test_adapters.py
@@ -191,6 +191,13 @@ class TestFetchHistoryModel(TestAdaptersBase):
         ret = request_obj.set_sort(value=attr, descending=True)
         assert ret == exp
 
+    def test_set_sort_empty(self, apiobj):
+        request_obj = json_api.adapters.AdapterFetchHistoryRequest()
+        attr = None
+        exp = None
+        ret = request_obj.set_sort(value=attr, descending=True)
+        assert ret == exp
+
     def test_set_filters_invalid_type(self, apiobj, history_filters):
         request_obj = json_api.adapters.AdapterFetchHistoryRequest()
         with pytest.raises(ApiError):

--- a/axonius_api_client/tests/tests_api/tests_assets/test_assets.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_assets.py
@@ -8,6 +8,7 @@ from axonius_api_client.api import json_api, mixins
 from axonius_api_client.constants.api import MAX_PAGE_SIZE
 from axonius_api_client.exceptions import ApiError, NotFoundError, StopFetch
 from axonius_api_client.tools import listify
+from flaky import flaky
 
 from ...meta import QUERIES
 from ...utils import check_asset, check_assets
@@ -354,6 +355,7 @@ class TestAssetsPublic(ModelMixinsBase):
         check_assets(rows)
         assert len(rows) == 20
 
+    @flaky(max_runs=3)
     def test_get_all_agg(self, apiobj):
         rows = apiobj.get(fields="agg:all", max_rows=5)
         for row in rows:

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -811,10 +811,10 @@ def validate_sq(asset):
         sort = view.pop("sort")
         assert isinstance(sort, dict)
 
-        sort_desc = sort.pop("desc")
+        sort_desc = sort.pop("desc", False)
         assert isinstance(sort_desc, bool)
 
-        sort_field = sort.pop("field")
+        sort_field = sort.pop("field", "")
         assert isinstance(sort_field, str)
         assert not sort
 
@@ -925,9 +925,10 @@ def validate_sq(asset):
 
     # 4.5: 2022/02/07
     assetConditionExpressions = view.pop("assetConditionExpressions", [])
-    assert isinstance(assetConditionExpressions, list)
+    assert isinstance(assetConditionExpressions, list) or assetConditionExpressions is None
+
     assetExcludeAdapters = view.pop("assetExcludeAdapters", [])
-    assert isinstance(assetExcludeAdapters, list)
+    assert isinstance(assetExcludeAdapters, list) or assetExcludeAdapters is None
 
     # 4.6: 2022/04/19
     queryStrings = view.pop("queryStrings", {})

--- a/axonius_api_client/tests/tests_api/tests_json_api/test_json_api.py
+++ b/axonius_api_client/tests/tests_api/tests_json_api/test_json_api.py
@@ -52,11 +52,11 @@ class TestJsonApi:
                 return SomeModel
 
         with pytest.raises(SchemaError) as exc:
-            SomeModel.load_response(data=[])
+            SomeModel.load_response(data=1)
         assert "Data to load must be a dictionary" in str(exc.value)
 
         with pytest.raises(SchemaError) as exc:
-            SomeSchema.load_response(data=[])
+            SomeSchema.load_response(data="x")
         assert "Data to load must be a dictionary" in str(exc.value)
 
         with pytest.raises(SchemaError) as exc:

--- a/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_get_query_history.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_saved_query/test_cmd_get_query_history.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Test suite for axonius_api_client.tools."""
+import pytest
+from axonius_api_client.cli import cli
+from axonius_api_client.tools import json_load
+
+from ...utils import load_clirunner
+
+
+class TestGrpSavedQueryCmdGetQueryHistory:
+    @pytest.mark.parametrize("export_format", ["json"])
+    def test_json_exports(self, request, monkeypatch, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args1 = [
+                "devices",
+                "saved-query",
+                "get-query-history",
+                "--export-format",
+                export_format,
+            ]
+            result1 = runner.invoke(cli=cli, args=args1)
+
+            assert result1.stdout
+            assert result1.stderr
+            assert result1.exit_code == 0
+
+            json1 = json_load(result1.stdout)
+            assert isinstance(json1, list) and json1
+            for item in json1:
+                assert isinstance(item, dict) and item
+
+    @pytest.mark.parametrize("export_format", ["csv", "table"])
+    def test_str_exports(self, request, monkeypatch, export_format):
+        runner = load_clirunner(request, monkeypatch)
+        with runner.isolated_filesystem():
+
+            args1 = [
+                "devices",
+                "saved-query",
+                "get-query-history",
+                "--export-format",
+                export_format,
+            ]
+            result1 = runner.invoke(cli=cli, args=args1)
+
+            assert result1.stdout
+            assert result1.stderr
+            assert result1.exit_code == 0

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.40.1"
+__version__ = "4.40.2"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
<!-- MarkdownTOC -->

- [4.40.2](#4402)
  - [Feature: Get Query History](#feature-get-query-history)
  - [Bugfix: Adapter specific Advanced settings using wrong schema](#bugfix-adapter-specific-advanced-settings-using-wrong-schema)

<!-- /MarkdownTOC -->

# 4.40.2

## Feature: Get Query History

New Methods:
- client.devices.saved_query.get_query_history
- client.devices.saved_query.get_query_history_generator
- client.devices.saved_query.get_query_history_run_by
- client.devices.saved_query.get_query_history_run_from

New Commands:
- axonshell devices saved-query get-query-history
- axonshell users saved-query get-query-history
- axonshell vulnerabilities saved-query get-query-history

## Bugfix: Adapter specific Advanced settings using wrong schema

This command would produce the wrong output:
```
axonshell adapters config-get -ct specific -n tenable_io
```

This command would fail due to mismatched schema:
```
axonshell adapters config-update -ct specific -n tenable_io -c exclude_no_last_scan=y
```

Both of these issues are addressed in this version.
