### PR TITLE
4.40.5

### DIFF
--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import re
 import textwrap
-from typing import ClassVar, List, Optional, Tuple, Type
+from typing import ClassVar, List, Optional, Pattern, Tuple, Type
 
 import marshmallow
 import marshmallow_jsonapi
@@ -588,7 +588,7 @@ class AdapterFetchHistoryFilters(BaseModel):
         def is_match(item):
             if isinstance(check, str) and item == check:
                 return True
-            if isinstance(check, re.Pattern) and check.search(item):
+            if isinstance(check, Pattern) and check.search(item):
                 return True
             return False
 
@@ -613,7 +613,7 @@ class AdapterFetchHistoryFilters(BaseModel):
             check = value.strip()
             if check.startswith("~"):
                 check = re.compile(check[1:])
-        elif isinstance(value, re.Pattern):
+        elif isinstance(value, Pattern):
             check = value
         elif value is None:
             return []

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import re
 import textwrap
-from typing import ClassVar, List, Optional, Tuple, Type, Union
+from typing import ClassVar, List, Optional, Pattern, Tuple, Type, Union
 
 import marshmallow
 import marshmallow_jsonapi
@@ -730,7 +730,7 @@ class QueryHistoryRequest(BaseModel):
                 check = value
                 if check.startswith("~"):
                     check = re.compile(check[1:])
-            elif isinstance(value, re.Pattern):
+            elif isinstance(value, Pattern):
                 check = value
             else:
                 raise ApiError(
@@ -742,7 +742,7 @@ class QueryHistoryRequest(BaseModel):
                     if check not in use_enum:
                         err(check=check, use_enum=use_enum)
                     matches.append(check)
-                elif isinstance(check, re.Pattern):
+                elif isinstance(check, Pattern):
                     re_matches = [x for x in use_enum if check.search(x)]
                     if not re_matches:
                         err(check=check, use_enum=use_enum)

--- a/axonius_api_client/connect.py
+++ b/axonius_api_client/connect.py
@@ -297,6 +297,7 @@ class Connect:
 
         self.SIGNUP = Signup(**self.HTTP_ARGS)
         """Easy access to signup."""
+        self._init()
 
     def start(self):
         """Connect to and authenticate with Axonius."""
@@ -539,3 +540,7 @@ class Connect:
         re.compile(r".*?\] (.*) "),
     ]
     """patterns to look for in exceptions that we can pretty up for user display."""
+
+    def _init(self):
+        """Pass."""
+        pass

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -82,7 +82,9 @@ class Http:
         self.RESPONSE_TIMEOUT: int = kwargs.get("response_timeout", TIMEOUT_RESPONSE)
         """seconds to wait for responses from :attr:`url` ``kwargs=response_timeout``"""
 
-        self.LOG_HIDE_HEADERS: List[str] = kwargs.get("log_hide_headers", ["api-key", "api-secret"])
+        self.LOG_HIDE_HEADERS: List[str] = kwargs.get(
+            "log_hide_headers", ["api-key", "api-secret", "Cookie"]
+        )
         """Headers to hide when logging."""
 
         self.LOG_REQUEST_BODY: bool = kwargs.get("log_request_body", False)
@@ -136,8 +138,12 @@ class Http:
         self.CERT_PATH: Optional[Union[str, pathlib.Path]] = certpath
         self.CERT_VERIFY: bool = certverify
         self.CERT_WARN: bool = certwarn
-        self.HTTP_HEADERS: T_Headers = headers if isinstance(headers, T_Headers) else {}
-        self.HTTP_COOKIES: T_Cookies = cookies if isinstance(cookies, T_Cookies) else {}
+        self.HTTP_HEADERS: T_Headers = (
+            headers if isinstance(headers, (dict, requests.structures.CaseInsensitiveDict)) else {}
+        )
+        self.HTTP_COOKIES: T_Cookies = (
+            cookies if isinstance(cookies, (dict, requests.cookies.RequestsCookieJar)) else {}
+        )
         self.log_request_attrs: Optional[List[str]] = self.LOG_REQUEST_ATTRS
         self.log_response_attrs: Optional[List[str]] = self.LOG_RESPONSE_ATTRS
 

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -164,6 +164,7 @@ class Http:
         self.set_urllib_warnings()
         self.set_urllib_log()
         self.new_session()
+        self._init()
 
     def get_cert(self) -> cert_human.Cert:
         """Pass."""
@@ -513,3 +514,7 @@ class Http:
         """
         body = json_log(obj=coerce_str(value=body), trim=self.LOG_BODY_MAX_LEN)
         return f"{body_type} BODY:\n{body}"
+
+    def _init(self):
+        """Pass."""
+        pass

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -404,13 +404,12 @@ class Http:
         """
 
         def getval(key, value):
-            skey = str(key)
+            skey = str(key).lower()
             for check in self.LOG_HIDE_HEADERS:
-                if isinstance(check, str) and check.lower() == skey.lower():
+                if (isinstance(check, str) and check.lower() == skey) or (
+                    isinstance(check, Pattern) and check.search(key)
+                ):
                     return self.HIDE_STR
-                if isinstance(check, Pattern) and check.search(key):
-                    return self.HIDE_STR
-
             return value
 
         try:

--- a/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks.py
+++ b/axonius_api_client/tests/tests_api/tests_asset_callbacks/test_callbacks.py
@@ -798,7 +798,8 @@ class CallbacksFull(Callbacks):
         cbobj = self.get_cbobj(apiobj=apiobj, cbexport=cbexport, getargs={"do_echo": False})
         cbobj.echo(msg=entry)
         capture = capsys.readouterr()
-        assert not capture.err
+        if sys.version_info >= (3, 8, 0):
+            assert not capture.err
         assert not capture.out
         log_check(caplog=caplog, entries=[entry], exists=True)
 

--- a/axonius_api_client/tests/tests_cli/tests_grp_meta/test_cmd_about.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_meta/test_cmd_about.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 """Test suite for axonius_api_client.tools."""
+import json
+
+import pytest
+from axonius_api_client import connect
 from axonius_api_client.tools import json_load
 
 from ....cli import cli
@@ -7,18 +11,13 @@ from ...utils import load_clirunner
 
 
 class TestGrpMetaCmdAbout:
+
+    ARGS = ["system", "meta", "about"]
+
     def test_export_json(self, request, monkeypatch):
         runner = load_clirunner(request, monkeypatch)
         with runner.isolated_filesystem():
-
-            args = [
-                "system",
-                "meta",
-                "about",
-                "--export-format",
-                "json",
-            ]
-            result = runner.invoke(cli=cli, args=args)
+            result = runner.invoke(cli=cli, args=[*self.ARGS, "--export-format", "json"])
             assert result.stdout
             assert result.stderr
             assert result.exit_code == 0
@@ -28,15 +27,77 @@ class TestGrpMetaCmdAbout:
     def test_export_str(self, request, monkeypatch):
         runner = load_clirunner(request, monkeypatch)
         with runner.isolated_filesystem():
-
-            args = [
-                "system",
-                "meta",
-                "about",
-                "--export-format",
-                "str",
-            ]
-            result = runner.invoke(cli=cli, args=args)
+            result = runner.invoke(cli=cli, args=[*self.ARGS, "--export-format", "str"])
             assert result.stdout
             assert result.stderr
             assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("option", ["header", "cookie"])
+class TestDictOptions:
+
+    ARGS = ["system", "meta", "about"]
+
+    def test_cmdline(self, request, monkeypatch, option):
+        orig = {"k1": "v1", "foobar": "cmdline"}
+        cmdline = []
+        for k, v in orig.items():
+            cmdline += [f"--{option}", f"{k}={v}"]
+
+        def checker(self):
+            """Pass."""
+            session = self.HTTP.session
+            obj = getattr(session, f"{option}s")
+            for k, v in orig.items():
+                assert obj[k] == v
+
+        runner = load_clirunner(request, monkeypatch)
+        with monkeypatch.context() as m:
+            m.setattr(connect.Connect, "_init", checker)
+            with runner.isolated_filesystem():
+                result = runner.invoke(cli=cli, args=[*cmdline, *self.ARGS])
+                assert result.stdout
+                assert result.stderr
+                assert result.exit_code == 0
+
+    def test_env_csv(self, request, monkeypatch, option):
+        orig = {"k1": "v1", "foobar": "csv"}
+        env_value = ",".join([f"{k}={v}" for k, v in orig.items()])
+
+        def checker(self):
+            """Pass."""
+            session = self.HTTP.session
+            obj = getattr(session, f"{option}s")
+            for k, v in orig.items():
+                assert obj[k] == v
+
+        runner = load_clirunner(request, monkeypatch)
+        with monkeypatch.context() as m:
+            m.setattr(connect.Connect, "_init", checker)
+            m.setenv(f"AX_{option.upper()}S", env_value)
+            with runner.isolated_filesystem():
+                result = runner.invoke(cli=cli, args=[*self.ARGS])
+                assert result.stdout
+                assert result.stderr
+                assert result.exit_code == 0
+
+    def test_env_json(self, request, monkeypatch, option):
+        orig = {"k1": "v1", "foobar": "json"}
+        env_value = f"json:{json.dumps(orig)}"
+
+        def checker(self):
+            """Pass."""
+            session = self.HTTP.session
+            obj = getattr(session, f"{option}s")
+            for k, v in orig.items():
+                assert obj[k] == v
+
+        runner = load_clirunner(request, monkeypatch)
+        with monkeypatch.context() as m:
+            m.setattr(connect.Connect, "_init", checker)
+            m.setenv(f"AX_{option.upper()}S", env_value)
+            with runner.isolated_filesystem():
+                result = runner.invoke(cli=cli, args=[*self.ARGS])
+                assert result.stdout
+                assert result.stderr
+                assert result.exit_code == 0

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -1619,3 +1619,12 @@ def extract_kvs_csv(value: Union[str, bytes, IO] = None, split_kv: str = "=", **
                     continue
                 ret[ikey] = ivalue
     return ret
+
+
+def tilde_re(value: Any) -> Optional[Union[str, Pattern]]:
+    """Pass."""
+    if isinstance(value, (list, tuple)):
+        return [tilde_re(x) for x in value]
+    if isinstance(value, str) and value.startswith("~"):
+        return re.compile(value[1:], re.I)
+    return value if isinstance(value, (str, Pattern)) else None

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.40.4"
+__version__ = "4.40.5"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
# 4.40.5
<!-- MarkdownTOC -->

- [Bugfix: python 3.6 does not have re.Pattern](#bugfix-python-36-does-not-have-repattern)
- [Bugfix: python 3.8 can not use typing.Union with isinstance](#bugfix-python-38-can-not-use-typingunion-with-isinstance)
- [Bugfix: Parsing of --header and --cookie was being mishandled](#bugfix-parsing-of---header-and---cookie-was-being-mishandled)
- [Bugfix: more header/cookie names should be hidden in logs by default](#bugfix-more-headercookie-names-should-be-hidden-in-logs-by-default)

<!-- /MarkdownTOC -->

## Bugfix: python 3.6 does not have re.Pattern

- now using typing.Pattern

## Bugfix: python 3.8 can not use typing.Union with isinstance

- Would throw error
`TypeError: Subscripted generics cannot be used with class and instance checks`

- now using isinstance(val, (...))

## Bugfix: Parsing of --header and --cookie was being mishandled

- fixed

## Bugfix: more header/cookie names should be hidden in logs by default

- list of keys used to be

```text
[
  "api-key",
  "api-secret",
]
```

- reworked to support string for exact key matches or regex patterns
- strings beginning with ~ will be turned into regex pattern
- list of keys is now

```text
[
  "~cookie",
  "~auth",
  "~token",
  "~^cf_",
  "~secret",
  "~key",
  "~username",
  "~password",
]
```
