### PR TITLE
4.40.8

### DIFF
--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -423,7 +423,11 @@ def tlens(value: t.Any) -> t.Optional[int]:
 
 
 def json_load(
-    obj: t.Union[str, t.IO, pathlib.Path], error: bool = True, close_fh: bool = True, **kwargs
+    obj: t.Union[str, t.IO, pathlib.Path],
+    error: bool = True,
+    load_file: bool = True,
+    close_fh: bool = True,
+    **kwargs,
 ) -> t.Any:
     """Deserialize a json str into an object.
 
@@ -435,7 +439,7 @@ def json_load(
     load = obj
     method = json.loads
     fh = None
-    if is_existing_file(load):
+    if load_file and is_existing_file(load):
         method = json.load
         path = pathify(obj)
         fh = load = path.open()

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.40.7"
+__version__ = "4.40.8"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
# 4.40.8
<!-- MarkdownTOC -->

- [Bugfix: updating a connection setting of type file would throw file not found error](#bugfix-updating-a-connection-setting-of-type-file-would-throw-file-not-found-error)
  - [Error](#error)
  - [Python Reproduction](#python-reproduction)
  - [Axonshell Reproduction](#axonshell-reproduction)
  - [Changes](#changes)

<!-- /MarkdownTOC -->

## Bugfix: updating a connection setting of type file would throw file not found error

### Error

```text
    raise ConfigInvalidValue(f"{sinfo}\nFile is not an existing file!")
axonius_api_client.exceptions.ConfigInvalidValue: Value "..." of type 'str' supplied for updating settings for connection Adapter Name: 'json', Instance name: 'Master', Instance ID: '55c35820b0284ac5ba28e7ab8f96683c', Connection ID: '55c35820b0284ac5ba28e7ab8f96683c', Connection UUID: '55c35820b0284ac5ba28e7ab8f96683c', Is active: True, Status: success setting 'file_path'
File is not an existing file!
```

### Python Reproduction

```python
cnx = client.adapters.cnx.get_by_adapter("json")[0]
updated = client.adapters.cnx.update_by_id(
    cnx_id=cnx["id"], adapter_name="json", file_path="~/workdir/json_adapter.json"
)
```

### Axonshell Reproduction

```bash
axonshell adapters cnx update-by-id -n json -i 635ab06b875e3b8ba0b1b9a6 -c file_path=~/workdir/json_adapter.json -npo
```

### Changes

- changed axonius_api_client.tools.json_load to not load contents from file if load_file=False
- changed axonius_api_client.adapters.cnx.Cnx.cb_file_upload to pass load_file=False when calling json_load