### PR TITLE
More features for 4.60.0

### DIFF
--- a/axonius_api_client/api/api_endpoint.py
+++ b/axonius_api_client/api/api_endpoint.py
@@ -110,15 +110,11 @@ class ApiEndpoint:
     def str_properties(self) -> t.List[str]:
         """Get the properties for this endpoint as a list of strs."""
         return [
-            f"method={self.method!r}",
-            f"path={self.path!r}",
+            f"method={self.method!r}, path={self.path!r}",
             f"request_schema={get_cls_path(self.request_schema_cls)}",
             f"request_model={get_cls_path(self.request_model_cls)}",
             f"response_schema={get_cls_path(self.response_schema_cls)}",
             f"response_model={get_cls_path(self.response_model_cls)}",
-            f"request_as_none={self.request_as_none}",
-            f"response_as_text={self.response_as_text}",
-            f"http_args_required={self.http_args_required}",
         ]
 
     def perform_request(
@@ -253,6 +249,10 @@ class ApiEndpoint:
             data = self.load_response(
                 http=http, response=response, **combo_dicts(kwargs, data=data)
             )
+            try:
+                data.RESPONSE = response
+            except Exception:
+                pass
         return data
 
     def get_response_json(self, response: requests.Response) -> JSON_TYPES:

--- a/axonius_api_client/api/api_endpoints.py
+++ b/axonius_api_client/api/api_endpoints.py
@@ -1291,6 +1291,31 @@ class DataScopes(ApiEndpointGroup):
 
 
 @dataclasses.dataclass(eq=True, frozen=True, repr=False)
+class Account(ApiEndpointGroup):
+    """Pass."""
+
+    login: ApiEndpoint = ApiEndpoint(
+        method="post",
+        path="api/login",
+        request_schema_cls=json_api.account.LoginRequestSchema,
+        request_model_cls=json_api.account.LoginRequest,
+        response_schema_cls=json_api.account.LoginResponseSchema,
+        response_model_cls=json_api.account.LoginResponse,
+    )
+
+    get_api_keys: ApiEndpoint = ApiEndpoint(
+        method="get",
+        path="api/settings/api_key",
+        request_schema_cls=None,
+        request_model_cls=None,
+        response_schema_cls=None,
+        response_model_cls=None,
+    )
+
+    validate: ApiEndpoint = SystemSettings.get_constants
+
+
+@dataclasses.dataclass(eq=True, frozen=True, repr=False)
 class ApiEndpoints(BaseData):
     """Pass."""
 
@@ -1313,6 +1338,7 @@ class ApiEndpoints(BaseData):
     dashboard_spaces: ApiEndpointGroup = DashboardSpaces()
     folders_queries: ApiEndpointGroup = FoldersQueries()
     folders_enforcements: ApiEndpointGroup = FoldersEnforcements()
+    account: ApiEndpointGroup = Account()
 
     @classmethod
     def get_groups(cls) -> Dict[str, ApiEndpointGroup]:

--- a/axonius_api_client/api/json_api/__init__.py
+++ b/axonius_api_client/api/json_api/__init__.py
@@ -2,6 +2,7 @@
 """Models for API requests & responses."""
 
 from . import (
+    account,
     adapters,
     assets,
     audit_logs,
@@ -57,4 +58,5 @@ __all__ = (
     "dashboard_spaces",
     "spaces_export",
     "folders",
+    "account",
 )

--- a/axonius_api_client/api/json_api/account.py
+++ b/axonius_api_client/api/json_api/account.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Models for API requests & responses."""
+import dataclasses
+import typing as t
+
+import marshmallow
+
+from ...exceptions import AuthError
+from .base import BaseModel, BaseSchemaJson
+from .custom_fields import SchemaBool
+from .generic import Metadata, MetadataSchema
+
+
+class LoginRequestSchema(BaseSchemaJson):
+    """Schema for issuing a login request."""
+
+    user_name = marshmallow.fields.Str(
+        allow_none=True,
+        dump_default=None,
+        load_default=None,
+        description="Axonius User Name",
+    )
+    password = marshmallow.fields.Str(
+        allow_none=True,
+        dump_default=None,
+        load_default=None,
+        description="Axonius Password",
+    )
+    saml_token = marshmallow.fields.Str(
+        allow_none=True,
+        dump_default=None,
+        load_default=None,
+        description="SAML token from 2FA negotiation",
+    )
+    remember_me = SchemaBool(
+        load_default=False, dump_default=False, description="Used for browser controls"
+    )
+    eula_agreed = SchemaBool(
+        load_default=False, dump_default=False, description="EULA has been agreed to by user"
+    )
+
+    class Meta:
+        """Pass."""
+
+        type_ = "login_schema"
+
+    @staticmethod
+    def get_model_cls() -> t.Optional[type]:
+        """Pass."""
+        return LoginRequest
+
+
+LOGIN_REQUEST_SCHEMA = LoginRequestSchema()
+
+
+@dataclasses.dataclass
+class LoginRequest(BaseModel):
+    """Model for issuing a login request."""
+
+    user_name: t.Optional[str] = None
+    password: t.Optional[str] = None
+    saml_token: t.Optional[str] = None
+    remember_me: bool = False
+    eula_agreed: bool = False
+
+    @staticmethod
+    def get_schema_cls() -> t.Optional[type]:
+        """Pass."""
+        return LoginRequestSchema
+
+    def _check_credential(self, attr: str) -> str:
+        """Check that a credential is a non-empty string."""
+        value: t.Any = getattr(self, attr)
+
+        if isinstance(value, str) and value.strip():
+            value = value.strip()
+            setattr(self, attr, value)
+            return value
+
+        field: marshmallow.Field = LOGIN_REQUEST_SCHEMA.declared_fields[attr]
+        description: str = field.metadata.get("description", f"{attr}")
+        msgs: t.List[str] = [
+            f"Value provided for {description} is not a non-empty string"
+            f"Provided type {type(value)}, value: {value!r}"
+        ]
+        raise AuthError(msgs)
+
+    def check_credentials(self):
+        """Check that username and password are not empty."""
+        self._check_credential(attr="user_name")
+        self._check_credential(attr="password")
+
+
+class LoginResponseSchema(MetadataSchema):
+    """Schema for receiving a login response."""
+
+    class Meta:
+        """Pass."""
+
+        type_ = "metadata_schema"
+
+    @staticmethod
+    def get_model_cls() -> t.Optional[type]:
+        """Pass."""
+        return LoginResponse
+
+
+@dataclasses.dataclass
+class LoginResponse(Metadata):
+    """Model for receiving a login response."""
+
+    document_meta: t.Optional[dict] = dataclasses.field(default_factory=dict)
+
+    @staticmethod
+    def get_schema_cls() -> t.Optional[type]:
+        """Pass."""
+        return LoginResponseSchema
+
+    @property
+    def access_token(self) -> str:
+        """Get the Access token for use in auth header."""
+        return self.document_meta["access_token"]
+
+    @property
+    def refresh_token(self) -> str:
+        """Get the Refresh token for use in auth header."""
+        return self.document_meta["refresh_token"]
+
+    @property
+    def authorization(self) -> str:
+        """Get the value to use in the authorization header."""
+        return f"Bearer {self.access_token}"

--- a/axonius_api_client/api/system/signup.py
+++ b/axonius_api_client/api/system/signup.py
@@ -143,4 +143,4 @@ class Signup:
         log_level = kwargs.get("log_level", LOG_LEVEL_API)
         self.LOG = get_obj_log(obj=self, level=log_level)
         kwargs.setdefault("certwarn", False)
-        self.http = Http(url=url, **kwargs)
+        self.HTTP = self.http = Http(url=url, **kwargs)

--- a/axonius_api_client/auth/__init__.py
+++ b/axonius_api_client/auth/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Authenticating with Axonius."""
-from . import api_key, models
+from . import api_key, credentials, models
 from .api_key import ApiKey
+from .credentials import Credentials
 from .models import Mixins, Model
 
 __all__ = (
@@ -10,4 +11,6 @@ __all__ = (
     "Model",
     "Mixins",
     "ApiKey",
+    "credentials",
+    "Credentials",
 )

--- a/axonius_api_client/auth/credentials.py
+++ b/axonius_api_client/auth/credentials.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Authentication via API key and API secret."""
+import typing as t
+
+from ..api.api_endpoints import ApiEndpoint
+from ..api.json_api.account import LoginRequest, LoginResponse
+from ..http import Http
+from .models import Mixins
+
+
+class Credentials(Mixins):
+    """Authentication method using username and password credentials."""
+
+    def __init__(
+        self,
+        http: Http,
+        username: t.Optional[str] = None,
+        password: t.Optional[str] = None,
+        **kwargs,
+    ):
+        """Authenticate using username and password.
+
+        Args:
+            http (Http): HTTP client to use to send requests
+            username (t.Optional[str], optional): Axonius User Name
+            password (t.Optional[str], optional): Axonius Password
+            prompt (bool, optional): Prompt for credentials that are not non-empty strings
+        """
+        creds: LoginRequest = LoginRequest(user_name=username, password=password, eula_agreed=True)
+        super().__init__(http=http, creds=creds, **kwargs)
+
+    def login(self):
+        """Login to API."""
+        if not self.is_logged_in:
+            self._creds.check_credentials()
+            self._login_response: LoginResponse = self._login(request_obj=self._creds)
+            headers: dict = {"authorization": self._login_response.authorization}
+            self._api_keys: dict = self._get_api_keys(headers=headers)
+            self.http.session.headers["api-key"] = self._api_keys["api_key"]
+            self.http.session.headers["api-secret"] = self._api_keys["api_secret"]
+            self._validate()
+            self._logged_in = True
+            self.LOG.debug(f"Successfully logged in using {self._cred_fields}")
+
+    def logout(self):
+        """Logout from API."""
+        super().logout()
+
+    def _login(self, request_obj: LoginRequest) -> LoginResponse:
+        """Direct API method to issue a login request.
+
+        Args:
+            request_obj (LoginRequest): Request object to send
+
+        Returns:
+            LoginResponse: Response object received
+        """
+        endpoint: ApiEndpoint = self.endpoints.login
+        response: LoginResponse = endpoint.perform_request(http=self.http, request_obj=request_obj)
+        return response
+
+    @property
+    def _cred_fields(self) -> t.List[str]:
+        """Credential fields used by this auth model."""
+        return [f"username={self._creds.user_name!r}", "password"]
+
+    def _logout(self):
+        """Logout from API."""
+        self._logged_in = False
+        self.http.session.headers = {}

--- a/axonius_api_client/cli/__init__.py
+++ b/axonius_api_client/cli/__init__.py
@@ -27,6 +27,7 @@ from ..logs import LOG
 from ..setup_env import DEFAULT_ENV_FILE
 from . import (
     context,
+    grp_account,
     grp_adapters,
     grp_assets,
     grp_certs,
@@ -371,6 +372,16 @@ Tips:
     type=click.INT,
     show_default=True,
 )
+@click.option(
+    "--credentials/--keys",
+    "-creds/-keys",
+    "credentials",
+    default=False,
+    help="Treat key as Username and secret as password",
+    is_flag=True,
+    show_envvar=True,
+    show_default=True,
+)
 @click.version_option(version.__version__)
 @context.pass_context
 @click.pass_context
@@ -397,3 +408,4 @@ cli.add_command(grp_certs.certs)
 cli.add_command(grp_enforcements.enforcements)
 cli.add_command(grp_spaces.spaces)
 cli.add_command(grp_folders.folders)
+cli.add_command(grp_account.account)

--- a/axonius_api_client/cli/grp_account/__init__.py
+++ b/axonius_api_client/cli/grp_account/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+import click
+
+from ..context import AliasedGroup, load_cmds
+from ..grp_tools import cmd_signup, cmd_use_token_reset_token, cmd_write_config
+
+
+@click.group(cls=AliasedGroup)
+def account():
+    """Group: Account commands."""
+
+
+load_cmds(path=__file__, package=__package__, group=account)
+account.add_command(cmd_write_config.cmd)
+account.add_command(cmd_signup.cmd)
+account.add_command(cmd_use_token_reset_token.cmd)

--- a/axonius_api_client/cli/grp_account/cmd_get_api_keys.py
+++ b/axonius_api_client/cli/grp_account/cmd_get_api_keys.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+
+from ..context import CONTEXT_SETTINGS, click
+from ..grp_tools.grp_common import EXPORT_FORMATS
+from ..grp_tools.grp_options import OPT_ENV, OPT_EXPORT
+from ..options import AUTH, add_options
+
+OPTIONS = [*AUTH, OPT_EXPORT, OPT_ENV]
+
+
+@click.command(name="get-api-keys", context_settings=CONTEXT_SETTINGS)
+@add_options(OPTIONS)
+@click.pass_context
+def cmd(ctx, url, key, secret, export_format, env):
+    """Get the API keys for the current user."""
+    client = ctx.obj.start_client(url=url, key=key, secret=secret)
+
+    with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
+        data = client.api_keys
+
+    click.secho(EXPORT_FORMATS[export_format](data=data, env=env, url=client.AUTH.http.url))
+    ctx.exit(0)

--- a/axonius_api_client/cli/grp_tools/cmd_signup.py
+++ b/axonius_api_client/cli/grp_tools/cmd_signup.py
@@ -1,52 +1,11 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-import datetime
-import typing as t
-
 import click
 
 from ...api import Signup
-from ...tools import json_dump
 from ..options import add_options
-
-
-def get_fb(obj: dict, keys: t.List[str]) -> str:
-    """Pass."""
-    for key in keys:
-        if key not in obj:
-            continue
-        value = obj.get(key, None)
-        if value:
-            return value
-    raise Exception(f"Unable to find any keys {keys} in dict {obj}")
-
-
-def export_str(data):
-    """Pass."""
-    date: datetime.datetime = datetime.datetime.utcnow()
-    ax_url: str = get_fb(obj=data, keys=["url"])
-    ax_secret: str = get_fb(obj=data, keys=["ax_secret", "api_secret"])
-    ax_key: str = get_fb(obj=data, keys=["ax_key", "api_key"])
-    ax_banner: str = f"signup on {date}"
-
-    lines = [
-        f'AX_URL="{ax_url}"',
-        f'AX_KEY="{ax_key}"',
-        f'AX_SECRET="{ax_secret}"',
-        f'AX_BANNER="{ax_banner}"',
-    ]
-    return "\n".join(lines)
-
-
-def export_json(data):
-    """Pass."""
-    return json_dump(data)
-
-
-EXPORT_FORMATS: dict = {
-    "json": export_json,
-    "str": export_str,
-}
+from .grp_common import EXPORT_FORMATS
+from .grp_options import OPT_ENV, OPT_EXPORT
 
 URL = click.option(
     "--url",
@@ -60,16 +19,6 @@ URL = click.option(
     show_default=True,
 )
 
-EXPORT = click.option(
-    "--export-format",
-    "-xf",
-    "export_format",
-    type=click.Choice(list(EXPORT_FORMATS)),
-    help="Format of to export data in",
-    default="str",
-    show_envvar=True,
-    show_default=True,
-)
 PASSWORD = click.option(
     "--password",
     "-p",
@@ -103,21 +52,22 @@ CONTACT = click.option(
     show_default=True,
 )
 
-OPTIONS = [URL, PASSWORD, COMPANY, CONTACT, EXPORT]
+OPTIONS = [URL, PASSWORD, COMPANY, CONTACT, OPT_EXPORT, OPT_ENV]
 
 
 @click.command(name="signup")
 @add_options(OPTIONS)
 @click.pass_context
-def cmd(ctx, url, password, company_name, contact_email, export_format):
+def cmd(ctx, url, password, company_name, contact_email, export_format, env):
     """Perform the initial signup to an instance."""
     entry = Signup(url=url)
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
         data = entry.signup(
             password=password, company_name=company_name, contact_email=contact_email
         )
-        data["url"] = url
 
-    click.secho(EXPORT_FORMATS[export_format](data=data))
+    click.secho(
+        EXPORT_FORMATS[export_format](data=data, signup=True, env=env, url=entry.auth.http.url)
+    )
     ctx.obj.echo_ok("Signup completed successfully!")
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_tools/cmd_use_token_reset_token.py
+++ b/axonius_api_client/cli/grp_tools/cmd_use_token_reset_token.py
@@ -36,8 +36,8 @@ OPTIONS = [URL, TOKEN, PASSWORD]
 @click.pass_context
 def cmd(ctx, url, token, password):
     """Use a password reset token."""
-    entry = Signup(url=url)
+    client = Signup(url=url)
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        name = entry.use_password_reset_token(token=token, password=password)
+        name = client.use_password_reset_token(token=token, password=password)
 
     ctx.obj.echo_ok(f"Password successfully reset for user {name!r}")

--- a/axonius_api_client/cli/grp_tools/grp_common.py
+++ b/axonius_api_client/cli/grp_tools/grp_common.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+import datetime
+import os
+import typing as t
+
+import click
+import dotenv
+
+from ...tools import get_path, json_dump
+
+AX_ENV: str = str(get_path(os.environ.get("AX_ENV", "") or ".env"))
+
+
+def multi_get(obj: dict, keys: t.List[str]) -> str:
+    """Pass."""
+    for key in keys:
+        if obj.get(key):
+            return obj[key]
+    raise Exception(f"Unable to find any keys {keys} in dict {obj}")
+
+
+def export_str(data: dict, url: str, signup: bool = False, **kwargs) -> str:
+    """Pass."""
+    ax_secret: str = multi_get(obj=data, keys=["ax_secret", "api_secret"])
+    ax_key: str = multi_get(obj=data, keys=["ax_key", "api_key"])
+    lines = [
+        f'AX_URL="{url}"',
+        f'AX_KEY="{ax_key}"',
+        f'AX_SECRET="{ax_secret}"',
+    ]
+    if signup:
+        lines.append(f'AX_BANNER="signup on {datetime.datetime.utcnow()}"')
+    return "\n".join(lines)
+
+
+def export_env(
+    data: dict, url: str, signup: bool = False, env: t.Optional[str] = AX_ENV, **kwargs
+) -> str:
+    """Pass."""
+    ax_secret: str = multi_get(obj=data, keys=["ax_secret", "api_secret"])
+    ax_key: str = multi_get(obj=data, keys=["ax_key", "api_key"])
+
+    env = get_path(env)
+    if not env.is_file():
+        click.secho(message=f"Creating file {str(env)!r}", err=True, fg="green")
+        env.touch()
+        env.chmod(0o600)
+    else:
+        click.secho(message=f"Updating file {str(env)!r}", err=True, fg="green")
+
+    click.secho(
+        message=f"Setting AX_URL, AX_KEY, and AX_SECRET in {str(env)!r}",
+        err=True,
+        fg="green",
+    )
+    dotenv.set_key(dotenv_path=str(env), key_to_set="AX_URL", value_to_set=url)
+    dotenv.set_key(dotenv_path=str(env), key_to_set="AX_KEY", value_to_set=ax_key)
+    dotenv.set_key(dotenv_path=str(env), key_to_set="AX_SECRET", value_to_set=ax_secret)
+    return ""
+
+
+def export_json(data: dict, url: str, **kwargs):
+    """Pass."""
+    data["url"] = url
+    return json_dump(data)
+
+
+EXPORT_FORMATS: dict = {
+    "json": export_json,
+    "str": export_str,
+    "env": export_env,
+}

--- a/axonius_api_client/cli/grp_tools/grp_options.py
+++ b/axonius_api_client/cli/grp_tools/grp_options.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Command line interface for Axonius API Client."""
+import click
+
+from .grp_common import AX_ENV, EXPORT_FORMATS
+
+OPT_EXPORT = click.option(
+    "--export-format",
+    "-xf",
+    "export_format",
+    type=click.Choice(list(EXPORT_FORMATS)),
+    help="Format of to export data in",
+    default="str",
+    show_envvar=True,
+    show_default=True,
+)
+
+OPT_ENV = click.option(
+    "--env",
+    "-e",
+    "env",
+    default=AX_ENV,
+    help="Path to .env file when --export-format==env",
+    show_envvar=True,
+    show_default=True,
+)

--- a/axonius_api_client/http.py
+++ b/axonius_api_client/http.py
@@ -516,8 +516,6 @@ class Http:
             body: content to log
             body_type: 'request' or 'response'
         """
-        if not isinstance(body, str):
-            body = ""
         body = json_log(obj=coerce_str(value=body), trim=self.LOG_BODY_MAX_LEN)
         return f"{body_type} BODY:\n{body}"
 

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -514,8 +514,6 @@ def json_load(
             f"Unable to load JSON from supplied {tlens(obj)}",
             f"error: {exc}",
         ]
-        msgs = "\n".join(msgs)
-        LOG.exception(msgs)
         if error:
             nexc = ToolsError(msgs)
             nexc.obj = obj


### PR DESCRIPTION
## Feature: Add ability to use username and password for credentials

### Axonshell changes

A new option is available to be used at the beginning of the command line:

```text
  -creds, --credentials / -keys, --keys
                                  Treat key as Username and secret as password
                                  [env var: AX_CREDENTIALS; default: keys]
````

This option, when used like:
```
axonshell -creds devices count
```

Will treat the value stored in --key or AX_KEY as username, and the value stored in --secret or AX_SECRET as the password.

### API changes

Connect has a new argument:

```python
credentials: bool = False
```

If this is True, key is treated as username and secret is treated as password and instead of using the Auth module ApiKey, it will use the new Auth module Credentials.

Credentials logs in with username and password, then fetches the api key and secret and uses that for the duration of the session.

## Feature: Get the API keys from an Axonius instance and write them to a file

A new command group has been added to Axonshell:

```text
Usage: axonshell account [OPTIONS] COMMAND [ARGS]...

  Group: Account commands.

Options:
  --help  Show this message and exit.

Commands:
  get-api-keys              Get the API keys for the current user.
  signup                    Perform the initial signup to an instance.
  use-password-reset-token  Use a password reset token.
  write-config              Create/Update a '.env' file with url, key,...

```

The signup, use-password-reset-token, and write-config commands are just copied over from axonshell tools.

The get-api-key command is a new command altogether:

```text
Usage: axonshell account get-api-keys [OPTIONS]

  Get the API keys for the current user.

Options:
  -u, --url URL                   URL of an Axonius instance  [env var:
                                  AX_URL; required]
  -k, --key KEY                   API Key of user in an Axonius instance  [env
                                  var: AX_KEY; required]
  -s, --secret SECRET             API Secret of user in an Axonius instance
                                  [env var: AX_SECRET; required]
  -xf, --export-format [json|str|env]
                                  Format of to export data in  [env var:
                                  AX_EXPORT_FORMAT; default: str]
  -e, --env TEXT                  Path to .env file when --export-format==env
                                  [env var: AX_ENV; default: .env]
  --help                          Show this message and exit.
```

You can use this with thew new --credentials option and have it prompt you for key (provide username), prompt you for secret (provide password) then create your .env file for you:

```
axonshell -creds account get-api-keys --url 1.1.1.1 --export-format env
```

## Feature: Add log filtering to hide potential credential storage

Created a logging formatter in axonius_api_client.logs:
```python

class HideFormatter(logging.Formatter):
    """Hide the rest of the line for any lines against :attr:`HIDE_REGEX`."""

    HIDE_ENABLED: bool = True
    """Enable hiding of matches to HIDE_REGEX."""
    HIDE_REGEX: t.Pattern = re.compile(r"(password|secret).*", re.I)
    """Pattern of sensitive info to hide."""
    HIDE_REPLACE: str = r"\1 ...REST OF LINE HIDDEN..."
    """Value to replace matches to HIDE_REGEX with."""
```

If any line in the logging output contains the word password or secret, the rest of the line after those words will be hidden from the logging system.