### PR TITLE
4.60.3

### DIFF
--- a/axonius_api_client/api/api_endpoint.py
+++ b/axonius_api_client/api/api_endpoint.py
@@ -250,7 +250,7 @@ class ApiEndpoint:
                 http=http, response=response, **combo_dicts(kwargs, data=data)
             )
             try:
-                data.RESPONSE = response
+                setattr(data, "RESPONSE", response)
             except Exception:
                 pass
         return data

--- a/axonius_api_client/api/json_api/adapters.py
+++ b/axonius_api_client/api/json_api/adapters.py
@@ -124,6 +124,12 @@ class AdapterFetchHistorySchema(BaseSchemaJson):
         load_default=None,
         dump_default=None,
     )
+    axonius_version = marshmallow.fields.Str(
+        description="The installed version of Axonius system at the time the fetch was initiated",
+        allow_none=True,
+        load_default=None,
+        dump_default=None,
+    )
 
     class Meta:
         """Pass."""
@@ -166,6 +172,11 @@ class AdapterFetchHistory(BaseModel):
 
     discovery_id: t.Optional[str] = get_field_dc_mm(
         mm_field=AdapterFetchHistorySchema._declared_fields["discovery_id"],
+        default=None,
+    )
+
+    axonius_version: t.Optional[str] = get_field_dc_mm(
+        mm_field=AdapterFetchHistorySchema._declared_fields["axonius_version"],
         default=None,
     )
 

--- a/axonius_api_client/api/json_api/base.py
+++ b/axonius_api_client/api/json_api/base.py
@@ -151,7 +151,7 @@ class BaseSchema(BaseCommon, marshmallow.Schema):
             SchemaError: if data is not a dict or list
         """
         many = isinstance(data, (list, tuple))
-        schema = cls(many=many)
+        schema = cls(many=many, unknown=marshmallow.INCLUDE)
 
         if not isinstance(data, (dict, list, tuple)):
             exc = ApiError(
@@ -212,9 +212,9 @@ class BaseSchemaJson(BaseSchema, marshmallow_jsonapi.Schema):
             else:
                 exc = ApiError(f"Data to load must be a dictionary, not a {type(data).__name__}")
                 raise SchemaError(schema=cls, exc=exc, data=data, obj=cls)
-
-        many = isinstance(data.get("data"), (list, tuple))
-        schema = cls(many=many)
+        inner_data: t.Any = data.get("data")
+        many: bool = isinstance(inner_data, (list, tuple))
+        schema = cls(many=many, unknown=marshmallow.INCLUDE)
         return cls._load_schema(**combo_dicts(kwargs, schema=schema, data=data))
 
     @classmethod
@@ -322,7 +322,7 @@ class BaseModel(dataclasses_json.DataClassJsonMixin, BaseCommon):
             return schema_cls.load_response(data=data, **kwargs)
 
         many = isinstance(data, (list, tuple))
-        schema = schema_cls(many=many)
+        schema = schema_cls(many=many, unknown=marshmallow.INCLUDE)
         if not isinstance(data, (dict, list, tuple)):
             exc = ApiError(
                 f"Data to load must be a dictionary or list, not a {type(data).__name__}"

--- a/axonius_api_client/api/json_api/data_scopes.py
+++ b/axonius_api_client/api/json_api/data_scopes.py
@@ -221,7 +221,7 @@ class DataScopeDetails(BaseModel):
 
     def get_scopes(self) -> t.List[DataScope]:
         """Pass."""
-        schema = DataScope.schema(many=True)
+        schema = DataScope.schema(many=True, unknown=marshmallow.INCLUDE)
         objs = schema.load(self.scopes, unknown=marshmallow.INCLUDE)
         for obj in objs:
             obj.HTTP = self.HTTP

--- a/axonius_api_client/api/json_api/folders/base.py
+++ b/axonius_api_client/api/json_api/folders/base.py
@@ -1526,7 +1526,9 @@ class Folder(abc.ABC, FolderBase):
 
         values = listify(values)
         values = [load(value=x, idx=idx) for idx, x in enumerate(values)]
-        items: t.List[Folder] = model.schema(many=True).load(values, unknown=marshmallow.INCLUDE)
+        items: t.List[Folder] = model.schema(many=True, unknown=marshmallow.INCLUDE).load(
+            values, unknown=marshmallow.INCLUDE
+        )
         return items
 
     @property

--- a/axonius_api_client/cli/__init__.py
+++ b/axonius_api_client/cli/__init__.py
@@ -208,6 +208,16 @@ Tips:
     show_envvar=True,
 )
 @click.option(
+    "--log-hide-secrets/--no-log-hide-secrets",
+    "-lhs/-nlhs",
+    "log_hide_secrets",
+    default=True,
+    help="Enable hiding of secrets in log output",
+    is_flag=True,
+    show_envvar=True,
+    show_default=True,
+)
+@click.option(
     "--log-console/--no-log-console",
     "-c/-nc",
     "log_console",

--- a/axonius_api_client/connect.py
+++ b/axonius_api_client/connect.py
@@ -49,7 +49,7 @@ from .constants.logs import (
 )
 from .exceptions import ConnectError, InvalidCredentials
 from .http import Http, T_Cookies, T_Headers
-from .logs import LOG, add_file, add_stderr, get_obj_log, set_log_level
+from .logs import LOG, HideFormatter, add_file, add_stderr, get_obj_log, set_log_level
 from .setup_env import get_env_ax
 from .tools import coerce_bool, coerce_int, json_dump, json_reload, sysinfo
 from .version import __version__ as VERSION
@@ -118,6 +118,7 @@ class Connect:
         headers: Optional[T_Headers] = None,
         cookies: Optional[T_Cookies] = None,
         credentials: bool = False,
+        log_hide_secrets: bool = True,
         **kwargs,
     ):
         """Easy all-in-one connection handler.
@@ -143,6 +144,7 @@ class Connect:
         certverify = coerce_bool(certverify)
         log_console = coerce_bool(log_console)
         log_file = coerce_bool(log_file)
+        self.LOG_HIDE_SECRETS: bool = coerce_bool(log_hide_secrets)
 
         self.TIMEOUT_CONNECT: int = coerce_int(kwargs.get("timeout_connect", TIMEOUT_CONNECT))
         """Seconds to wait for connections to open to :attr:`url` ``kwargs=timeout_connect``"""
@@ -252,6 +254,7 @@ class Connect:
 
         self.HANDLER_CON: logging.StreamHandler = None
         """console logging handler"""
+        HideFormatter.HIDE_ENABLED = self.LOG_HIDE_SECRETS
 
         if log_console:
             self.HANDLER_CON = add_stderr(

--- a/axonius_api_client/tests/tests_cli/tests_grp_tools/test_cmd_write_config.py
+++ b/axonius_api_client/tests/tests_cli/tests_grp_tools/test_cmd_write_config.py
@@ -18,21 +18,20 @@ class TestCmdWriteConfig(object):
 
         prompt_input = "\n".join([url, key, secret])
 
-        args = ["tools", "write-config"]
-
         with runner.isolated_filesystem():
             path = pathlib.Path(os.getcwd())
             envfile = path / ".env"
+            args = ["tools", "write-config", "--env", f"{envfile}"]
             result1 = runner.invoke(cli=cli, args=args, input=prompt_input)
             assert envfile.is_file()
-            assert result1.stdout
+            assert not result1.stdout
             assert result1.stderr
             assert "Creating file" in result1.stderr
             assert result1.exit_code == 0
 
             result2 = runner.invoke(cli=cli, args=args, input=prompt_input)
             assert envfile.is_file()
-            assert result2.stdout
+            assert not result2.stdout
             assert result2.stderr
             assert "Updating file" in result2.stderr
             assert result2.exit_code == 0

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "4.60.2"
+__version__ = "4.60.3"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
# 4.60.3
<!-- MarkdownTOC -->

- [Bugfix: Error while getting dashboard spaces](#bugfix-error-while-getting-dashboard-spaces)
- [Bugfix: Warning while getting adapter fetch history events](#bugfix-warning-while-getting-adapter-fetch-history-events)
- [Feature: Add option to disable log secret hiding](#feature-add-option-to-disable-log-secret-hiding)

<!-- /MarkdownTOC -->

## Bugfix: Error while getting dashboard spaces

The schema for Chart objects within Dashboard Spaces was raising errors due to newly added attributes 'shared' and 'private'.

## Bugfix: Warning while getting adapter fetch history events

The schema for Adapter Fetch History Events was raising warnings due to newly added attributes 'axonius_version'.

## Feature: Add option to disable log secret hiding

New command line argument for axonshell:

```text
-lhs, --log-hide-secrets / -nlhs, --no-log-hide-secrets
                                Enable hiding of secrets in log output  [env
                                var: AX_LOG_HIDE_SECRETS; default: log-hide-
                                secrets]
```

New parameter for `axonius_api_client.connect.Connect`:

```text
log_hide_secrets: bool = True
log_hide_secrets: enable or disable hiding of secrets in logging system
```
