### PR TITLE
5.0.1

### DIFF
--- a/axonius_api_client/api/asset_callbacks/base.py
+++ b/axonius_api_client/api/asset_callbacks/base.py
@@ -183,7 +183,9 @@ class Base:
             "field_null_value": None,
             "field_null_value_complex": [],
             "tags_add": [],
+            "tags_add_invert_selection": False,
             "tags_remove": [],
+            "tags_remove_invert_selection": False,
             "report_adapters_missing": False,
             "report_software_whitelist": [],
             "page_progress": 10000,
@@ -804,17 +806,23 @@ class Base:
         """Add tags to assets."""
         tags_add = listify(self.get_arg_value("tags_add"))
         rows_add = self.TAG_ROWS_ADD
+        invert_selection = self.get_arg_value("tags_add_invert_selection")
         if tags_add and rows_add:
             self.echo(msg=f"Adding tags {tags_add} to {len(rows_add)} assets")
-            self.APIOBJ.labels.add(rows=rows_add, labels=tags_add)
+            self.APIOBJ.labels.add(
+                rows=rows_add, labels=tags_add, invert_selection=invert_selection
+            )
 
     def do_tag_remove(self):
         """Remove tags from assets."""
         tags_remove = listify(self.get_arg_value("tags_remove"))
         rows_remove = self.TAG_ROWS_REMOVE
+        invert_selection = self.get_arg_value("tags_remove_invert_selection")
         if tags_remove and rows_remove:
             self.echo(msg=f"Removing tags {tags_remove} from {len(rows_remove)} assets")
-            self.APIOBJ.labels.remove(rows=rows_remove, labels=tags_remove)
+            self.APIOBJ.labels.remove(
+                rows=rows_remove, labels=tags_remove, invert_selection=invert_selection
+            )
 
     def process_tags_to_add(self, rows: Union[List[dict], dict]) -> List[dict]:
         """Add assets to tracker for adding tags.
@@ -1420,7 +1428,9 @@ ARG_DESCRIPTIONS: dict = {
     "field_null_value": "Null value to use for missing simple fields",
     "field_null_value_complex": "Null value to use for missing complex fields",
     "tags_add": "Tags to add to assets",
+    "tags_add_invert_selection": "Invert selection for tags to add",
     "tags_remove": "Tags to remove from assets",
+    "tags_remove_invert_selection": "Invert selection for tags to remove",
     "report_adapters_missing": "Add Missing Adapters calculation",
     "report_software_whitelist": "Missing Software to calculate",
     "page_progress": "Echo page progress every N assets",

--- a/axonius_api_client/api/assets/asset_mixin.py
+++ b/axonius_api_client/api/assets/asset_mixin.py
@@ -1823,6 +1823,9 @@ class AssetMixin(ModelMixins):
         self.labels: Labels = Labels(parent=self)
         """Work with labels (tags)."""
 
+        self.tags = self.labels
+        """Alias for :attr:`labels`."""
+
         self.saved_query: SavedQuery = SavedQuery(parent=self)
         """Work with saved queries."""
 

--- a/axonius_api_client/api/assets/asset_mixin.py
+++ b/axonius_api_client/api/assets/asset_mixin.py
@@ -1153,6 +1153,7 @@ class AssetMixin(ModelMixins):
             fields_default: include the default fields in :attr:`fields_default`
             fields_root: include all fields of an adapter that are not complex sub-fields
             fields_error: throw validation errors on supplied fields
+            fields_parsed: previously parsed fields
             max_rows: only return N rows
             max_pages: only return N pages
             row_start: start at row N
@@ -1172,7 +1173,6 @@ class AssetMixin(ModelMixins):
             wiz_entries: wizard expressions to create query from
             file_date: string to use in filename templates for {DATE}
             wiz_parsed: parsed output from a query wizard
-            fields_parsed: previously parsed fields
             sort_field_parsed: previously parsed sort field
             history_date_parsed: previously parsed history date
             initial_count: previously fetched initial count

--- a/axonius_api_client/api/assets/saved_query.py
+++ b/axonius_api_client/api/assets/saved_query.py
@@ -992,6 +992,8 @@ class SavedQuery(ChildMixins):
         folder: t.Optional[t.Union[str, FolderModel]] = None,
         create: bool = FolderDefaults.create_action,
         echo: bool = FolderDefaults.echo_action,
+        enforcement_filter: t.Optional[str] = None,
+        unique_adapters: bool = False,
         **kwargs,
     ) -> models.SavedQueryCreate:
         """Create a saved query.
@@ -1057,11 +1059,11 @@ class SavedQuery(ChildMixins):
             create: create folder if it does not exist
             echo: echo folder actions to stdout/stderr
             sort_field_parsed: previously parsed sort field
-
+            enforcement_filter: unknown
+            unique_adapters: unknown
 
         Returns:
             models.SavedQueryCreate: saved query dataclass to create
-
         """
         asset_scope = coerce_bool(asset_scope)
         private = coerce_bool(private)
@@ -1106,20 +1108,24 @@ class SavedQuery(ChildMixins):
                 fields_error=True,
             )
         if not isinstance(sort_field_parsed, str):
-            sort_field_parsed: str = self.parent.fields.get_field_name(value=sort_field) or ""
+            sort_field_parsed: str = (
+                self.parent.fields.get_field_name(value=sort_field) if sort_field else ""
+            )
 
-        view_sort: dict = {
-            "desc": sort_descending,
-            "field": sort_field_parsed,
+        view_query_meta: dict = {
+            "enforcementFilter": enforcement_filter or "",
+            "uniqueAdapters": unique_adapters,
         }
         view_query: dict = {
             "filter": query or "",
             "expressions": expressions or [],
             "search": None,
-            "meta": {},
-            "enforcementFilter": None,
-            "uniqueAdapters": False,
+            "meta": view_query_meta,
             "onlyExpressionsFilter": query_expr or "",
+        }
+        view_sort: dict = {
+            "desc": sort_descending,
+            "field": sort_field_parsed or "",
         }
         view: dict = {
             "fields": fields_parsed,

--- a/axonius_api_client/api/json_api/account/current_user.py
+++ b/axonius_api_client/api/json_api/account/current_user.py
@@ -11,32 +11,40 @@ from ..custom_fields import SchemaBool, SchemaDatetime, field_from_mm
 
 
 class CurrentUserSchema(BaseSchemaJson):
-    """Schema for receiving current user response."""
+    """Schema for receiving current user response.
 
-    id = mm_fields.Str()
-    uuid = mm_fields.Str()
-    role_id = mm_fields.Str()
-    role_name = mm_fields.Str()
-    user_name = mm_fields.Str()
-    password = mm_fields.Str()
-    source = mm_fields.Str()
-    first_name = mm_fields.Str()
-    last_name = mm_fields.Str()
-    email = mm_fields.Str()
-    department = mm_fields.Str()
-    title = mm_fields.Str()
-    pic_name = mm_fields.Str()
-    predefined = SchemaBool()
-    is_axonius_role = SchemaBool()
-    interests = mm_fields.Dict(load_default=dict, dump_default=dict)
-    permissions = mm_fields.Dict(load_default=dict, dump_default=dict)
-    data_scope = mm_fields.Dict(dump_default=dict, load_default=dict)
+    This schema does not match the REST API definition because it does not
+    follow its own rules. email is defined as allow_none=False in REST API,
+    however it can come back as None from REST API.
+
+    Since it happened once, we are setting allow_none=True on all fields for
+    safety since we get this object anytime str(Connect()) is called.
+    """
+
+    id = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    uuid = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    role_id = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    role_name = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    user_name = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    password = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    source = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    first_name = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    last_name = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    email = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    department = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    title = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    pic_name = mm_fields.Str(allow_none=True, load_default=None, dump_default=None)
+    predefined = SchemaBool(allow_none=True, load_default=False, dump_default=False)
+    is_axonius_role = SchemaBool(allow_none=True, load_default=False, dump_default=False)
+    interests = mm_fields.Dict(allow_none=True, load_default=dict, dump_default=dict)
+    permissions = mm_fields.Dict(allow_none=True, load_default=dict, dump_default=dict)
+    data_scope = mm_fields.Dict(allow_none=True, dump_default=dict, load_default=dict)
     allowed_scopes_impersonation = mm_fields.List(
-        mm_fields.Str, load_default=list, dump_default=list
+        mm_fields.Str, allow_none=True, load_default=list, dump_default=list
     )
-    timeout = mm_fields.Integer(load_default=None, dump_default=None, alllow_none=True)
-    last_updated = SchemaDatetime(load_default=None, dump_default=None, allow_none=True)
-    last_login = SchemaDatetime(load_default=None, dump_default=None, allow_none=True)
+    timeout = mm_fields.Integer(allow_none=True, load_default=None, dump_default=None)
+    last_updated = SchemaDatetime(allow_none=True, load_default=None, dump_default=None)
+    last_login = SchemaDatetime(allow_none=True, load_default=None, dump_default=None)
 
     class Meta:
         """JSONAPI config."""
@@ -56,24 +64,24 @@ SCHEMA = CurrentUserSchema()
 class CurrentUser(BaseModel):
     """Model for receiving current user response."""
 
-    id: str = field_from_mm(SCHEMA, "id")
-    uuid: str = field_from_mm(SCHEMA, "uuid")
-    role_id: str = field_from_mm(SCHEMA, "role_id")
-    role_name: str = field_from_mm(SCHEMA, "role_name")
-    user_name: str = field_from_mm(SCHEMA, "user_name")
-    password: str = field_from_mm(SCHEMA, "password")
-    source: str = field_from_mm(SCHEMA, "source")
-    first_name: str = field_from_mm(SCHEMA, "first_name")
-    last_name: str = field_from_mm(SCHEMA, "last_name")
-    email: str = field_from_mm(SCHEMA, "email")
-    department: str = field_from_mm(SCHEMA, "department")
-    title: str = field_from_mm(SCHEMA, "title")
-    pic_name: str = field_from_mm(SCHEMA, "pic_name")
-    predefined: bool = field_from_mm(SCHEMA, "predefined")
-    is_axonius_role: bool = field_from_mm(SCHEMA, "is_axonius_role")
-    permissions: dict = field_from_mm(SCHEMA, "permissions", repr=False)
-    interests: dict = field_from_mm(SCHEMA, "interests")
-    data_scope: dict = field_from_mm(SCHEMA, "data_scope")
+    id: t.Optional[str] = field_from_mm(SCHEMA, "id")
+    uuid: t.Optional[str] = field_from_mm(SCHEMA, "uuid")
+    role_id: t.Optional[str] = field_from_mm(SCHEMA, "role_id")
+    role_name: t.Optional[str] = field_from_mm(SCHEMA, "role_name")
+    user_name: t.Optional[str] = field_from_mm(SCHEMA, "user_name")
+    password: t.Optional[str] = field_from_mm(SCHEMA, "password")
+    source: t.Optional[str] = field_from_mm(SCHEMA, "source")
+    first_name: t.Optional[str] = field_from_mm(SCHEMA, "first_name")
+    last_name: t.Optional[str] = field_from_mm(SCHEMA, "last_name")
+    email: t.Optional[str] = field_from_mm(SCHEMA, "email")
+    department: t.Optional[str] = field_from_mm(SCHEMA, "department")
+    title: t.Optional[str] = field_from_mm(SCHEMA, "title")
+    pic_name: t.Optional[str] = field_from_mm(SCHEMA, "pic_name")
+    predefined: t.Optional[bool] = field_from_mm(SCHEMA, "predefined")
+    is_axonius_role: t.Optional[bool] = field_from_mm(SCHEMA, "is_axonius_role")
+    permissions: t.Optional[dict] = field_from_mm(SCHEMA, "permissions", repr=False)
+    interests: t.Optional[dict] = field_from_mm(SCHEMA, "interests")
+    data_scope: t.Optional[dict] = field_from_mm(SCHEMA, "data_scope")
     allowed_scopes_impersonation: t.List[str] = field_from_mm(
         SCHEMA, "allowed_scopes_impersonation"
     )
@@ -91,14 +99,20 @@ class CurrentUser(BaseModel):
         return CurrentUserSchema
 
     @property
-    def last_login_seconds_ago(self) -> float:
+    def last_login_seconds_ago(self) -> t.Optional[float]:
         """Get the number of seconds since last login."""
-        return round(self.last_login_delta.total_seconds(), 2)
+        delta = self.last_login_delta
+        if isinstance(delta, datetime.timedelta):
+            return round(delta.total_seconds(), 2)
 
     @property
-    def last_login_delta(self) -> datetime.timedelta:
+    def last_login_delta(self) -> t.Optional[datetime.timedelta]:
         """Get the timedelta since last login."""
-        return datetime.datetime.now(datetime.timezone.utc) - self.last_login
+        from ....tools import dt_parse
+
+        last_login = dt_parse(self.last_login, allow_none=True)
+        if last_login:
+            return datetime.datetime.now(datetime.timezone.utc) - last_login
 
     @property
     def str_connect(self) -> str:

--- a/axonius_api_client/api/json_api/account/login_request.py
+++ b/axonius_api_client/api/json_api/account/login_request.py
@@ -5,7 +5,6 @@ import typing as t
 
 from marshmallow_jsonapi import fields as mm_fields
 
-from ....exceptions import AuthError
 from ..base import BaseModel, BaseSchemaJson
 from ..custom_fields import SchemaBool, field_from_mm
 
@@ -68,33 +67,7 @@ class LoginRequest(BaseModel):
 
     SCHEMA: t.ClassVar[BaseSchemaJson] = SCHEMA
 
-    def __post_init__(self):
-        """Post init."""
-        self.check_credentials()
-
     @staticmethod
     def get_schema_cls() -> t.Any:
         """Pass."""
         return LoginRequestSchema
-
-    def _check_credential(self, attr: str) -> str:
-        """Check that a credential is a non-empty string."""
-        value: t.Any = getattr(self, attr)
-
-        if isinstance(value, str) and value.strip():
-            value = value.strip()
-            setattr(self, attr, value)
-            return value
-
-        field: mm_fields.Field = SCHEMA.declared_fields[attr]
-        description: str = field.metadata.get("description", f"{attr}")
-        msgs: t.List[str] = [
-            f"Value provided for {description} is not a non-empty string",
-            f"Provided type {type(value)}, value: {value!r}",
-        ]
-        raise AuthError(msgs)
-
-    def check_credentials(self):
-        """Check that username and password are not empty."""
-        self._check_credential(attr="user_name")
-        self._check_credential(attr="password")

--- a/axonius_api_client/api/json_api/adapters/adapter_node.py
+++ b/axonius_api_client/api/json_api/adapters/adapter_node.py
@@ -257,6 +257,13 @@ class AdapterNodeCnx(BaseModel):
     did_notify_error: t.Optional[bool] = None
     note: t.Optional[t.Any] = None
 
+    # 2023/04/02
+    last_successful_fetch: t.Optional[datetime.datetime] = get_field_dc_mm(
+        mm_field=SchemaDatetime(allow_none=True), default=None
+    )
+    latest_configuration_change: t.Optional[datetime.datetime] = get_field_dc_mm(
+        mm_field=SchemaDatetime(allow_none=True), default=None
+    )
     document_meta: t.Optional[dict] = dataclasses.field(default_factory=dict)
 
     AdapterNode: t.ClassVar[AdapterNode] = None

--- a/axonius_api_client/api/json_api/adapters/fetch_history_response.py
+++ b/axonius_api_client/api/json_api/adapters/fetch_history_response.py
@@ -211,7 +211,9 @@ class AdapterFetchHistory(BaseModel):
         def getval(prop: str, width: t.Optional[int] = 30) -> str:
             """Pass."""
             value = getattr(self, prop, None)
-            if isinstance(width, int) and len(str(value)) > width:
+            if not isinstance(value, str):
+                value = "" if value is None else str(value)
+            if isinstance(width, int) and len(value) > width:
                 value = textwrap.fill(value, width=width)
             prop = prop.replace("_", " ").title()
             return f"{prop}: {value}"

--- a/axonius_api_client/api/json_api/adapters/fetch_history_response.py
+++ b/axonius_api_client/api/json_api/adapters/fetch_history_response.py
@@ -116,6 +116,17 @@ class AdapterFetchHistorySchema(BaseSchemaJson):
         load_default=None,
         dump_default=None,
     )
+    has_configuration_changed = SchemaBool(
+        description="Shows if the configuration changed since last fetch",
+        load_default=False,
+        dump_default=False,
+    )
+    last_fetch_time = SchemaDatetime(
+        description="The last fetch time",
+        allow_none=True,
+        load_default=None,
+        dump_default=None,
+    )
 
     class Meta:
         """JSONAPI config."""
@@ -159,6 +170,8 @@ class AdapterFetchHistory(BaseModel):
     ignored_devices_count: t.Optional[int] = field_from_mm(SCHEMA, "ignored_devices_count")
     ignored_users_count: t.Optional[int] = field_from_mm(SCHEMA, "ignored_users_count")
     realtime: bool = field_from_mm(SCHEMA, "realtime")
+    has_configuration_changed: bool = field_from_mm(SCHEMA, "has_configuration_changed")
+    last_fetch_time: t.Optional[datetime.datetime] = field_from_mm(SCHEMA, "last_fetch_time")
 
     document_meta: t.Optional[dict] = dataclasses.field(default_factory=dict)
 

--- a/axonius_api_client/api/json_api/assets/asset_id_response.py
+++ b/axonius_api_client/api/json_api/assets/asset_id_response.py
@@ -52,7 +52,7 @@ class AssetByIdSchema(BaseSchemaJson):
         description="Data for this asset",
     )
     labels = mm_fields.List(
-        mm_fields.Dict(),
+        mm_fields.Str(),
         load_default=list,
         dump_default=list,
         allow_none=True,
@@ -110,7 +110,7 @@ class AssetById(BaseModel):
     basic: dict = field_from_mm(SCHEMA, "basic")
     aggregated_specific_data: dict = field_from_mm(SCHEMA, "aggregated_specific_data")
     data: t.List[dict] = field_from_mm(SCHEMA, "data")
-    labels: t.List[dict] = field_from_mm(SCHEMA, "labels")
+    labels: t.List[str] = field_from_mm(SCHEMA, "labels")
     expirable_tags: t.List[dict] = field_from_mm(SCHEMA, "expirable_tags")
     labels_metadata: t.List[dict] = field_from_mm(SCHEMA, "labels_metadata")
     compliance_meta: dict = field_from_mm(SCHEMA, "compliance_meta")

--- a/axonius_api_client/api/json_api/saved_queries.py
+++ b/axonius_api_client/api/json_api/saved_queries.py
@@ -711,7 +711,8 @@ class SavedQuery(BaseModel, SavedQueryMixins):
     def to_tablize(self) -> dict:
         """Get tablize-able repr of this obj."""
         col_info = [
-            f"{k.upper()}={textwrap.fill(v or '', width=30)}" for k, v in self.col_info.items()
+            f"{k.upper()}={textwrap.fill('' if v is None else str(v), width=30)}"
+            for k, v in self.col_info.items()
         ]
         col_details = [f"{k}: {v}" for k, v in self.col_details.items()]
         ret = {}
@@ -1066,7 +1067,7 @@ class QueryHistory(BaseModel):
         def getval(prop):
             value = getattr(self, prop, None)
             if isinstance(value, list):
-                value = "\n".join(value)
+                value = "\n".join([str(x) for x in value])
             return value
 
         return {k: getval(k) for k in self._props_csv()}
@@ -1076,7 +1077,9 @@ class QueryHistory(BaseModel):
 
         def getval(prop, width=30):
             value = getattr(self, prop, None)
-            if isinstance(width, int) and len(str(value)) > width:
+            if not isinstance(value, str):
+                value = "" if value is None else str(value)
+            if isinstance(width, int) and len(value) > width:
                 value = textwrap.fill(value, width=width)
             prop = prop.replace("_", " ").title()
             return f"{prop}: {value}"

--- a/axonius_api_client/api/json_api/tasks/task_filters.py
+++ b/axonius_api_client/api/json_api/tasks/task_filters.py
@@ -7,12 +7,12 @@ import marshmallow
 import marshmallow_jsonapi.fields as mm_fields
 import click
 
-from axonius_api_client.constants.api import RE_PREFIX
-from axonius_api_client.constants.ctypes import PatternLike, TypeMatch
-from axonius_api_client.constants.general import SPLITTER
-from axonius_api_client.exceptions import NotFoundError
-from axonius_api_client.parsers.matcher import Matcher
-from axonius_api_client.tools import coerce_int, listify
+from ....constants.api import RE_PREFIX
+from ....constants.ctypes import PatternLike, TypeMatch
+from ....constants.general import SPLITTER
+from ....exceptions import NotFoundError
+from ....parsers.matcher import Matcher
+from ....tools import coerce_int, listify
 from ..base2 import BaseModel, BaseSchema
 from ..custom_fields import field_from_mm
 

--- a/axonius_api_client/api/openapi/openapi_spec.py
+++ b/axonius_api_client/api/openapi/openapi_spec.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """API for working with the OpenAPI specification file."""
 
-
-from axonius_api_client.api.api_endpoints import ApiEndpoints
-from axonius_api_client.api.mixins import ModelMixins
+from ..api_endpoints import ApiEndpoints
+from ..mixins import ModelMixins
 
 
 class OpenAPISpec(ModelMixins):

--- a/axonius_api_client/api/system/instances.py
+++ b/axonius_api_client/api/system/instances.py
@@ -564,7 +564,7 @@ class Instances(ModelMixins):
             **kwargs: passed to :meth:`upload_script`
         """
         if is_url(value=path):
-            from axonius_api_client.projects.url_parser import UrlParser
+            from ...projects.url_parser import UrlParser
 
             parser = UrlParser(url=path)
             path_part = pathlib.Path(parser.parsed.path)

--- a/axonius_api_client/api/system/settings.py
+++ b/axonius_api_client/api/system/settings.py
@@ -3,7 +3,7 @@
 import pathlib
 from typing import Any, List, Optional, Tuple, Union
 
-from axonius_api_client.projects import cert_human
+from ...projects import cert_human
 from ...constants.api import USE_CA_PATH
 from ...exceptions import ApiError, NotFoundError
 from ...parsers.config import config_build, config_unchanged, config_unknown, parse_settings

--- a/axonius_api_client/cli/context.py
+++ b/axonius_api_client/cli/context.py
@@ -259,7 +259,9 @@ class Context:
         """Pass."""
         return self._connect_args.get("wraperror", True)
 
-    def create_client(self, url, key, secret, **kwargs):
+    def create_client(
+        self, url: str, key: t.Optional[str] = None, secret: t.Optional[str] = None, **kwargs
+    ):
         """Pass."""
         connect_args = {}
         connect_args.update(self._connect_args)

--- a/axonius_api_client/cli/grp_assets/cmds_run_enforcement.py
+++ b/axonius_api_client/cli/grp_assets/cmds_run_enforcement.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-from axonius_api_client.constants.fields import AXID
-
+from ...constants.fields import AXID
 from ..context import CONTEXT_SETTINGS, click
 from ..options import AUTH, add_options
 

--- a/axonius_api_client/cli/grp_assets/grp_common.py
+++ b/axonius_api_client/cli/grp_assets/grp_common.py
@@ -492,6 +492,16 @@ GET_EXPORT = [
         metavar="TAG",
     ),
     click.option(
+        "--tag-invert/--no-tag-invert",
+        "tags_add_invert_selection",
+        default=asset_callbacks.Base.args_map()["tags_add_invert_selection"],
+        help="Only add tags to assets that do NOT match the query provided",
+        show_envvar=True,
+        show_default=True,
+        is_flag=True,
+        hidden=False,
+    ),
+    click.option(
         "--untag",
         "tags_remove",
         help="Tags to remove from each asset (multiples)",
@@ -501,6 +511,16 @@ GET_EXPORT = [
         show_default=True,
         hidden=False,
         metavar="TAG",
+    ),
+    click.option(
+        "--untag-invert/--no-untag-invert",
+        "tags_remove_invert_selection",
+        default=asset_callbacks.Base.args_map()["tags_remove_invert_selection"],
+        help="Only remove tags from assets that do NOT match the query provided",
+        show_envvar=True,
+        show_default=True,
+        is_flag=True,
+        hidden=False,
     ),
     click.option(
         "--include-details/--no-include-details",

--- a/axonius_api_client/cli/grp_enforcements/grp_tasks/export_get.py
+++ b/axonius_api_client/cli/grp_enforcements/grp_tasks/export_get.py
@@ -4,8 +4,8 @@ import codecs
 import csv
 import io
 
-from axonius_api_client.api.json_api.tasks import Task
-from axonius_api_client.tools import json_dump, path_write
+from ....api.json_api.tasks import Task
+from ....tools import json_dump, path_write
 from ...context import click
 
 

--- a/axonius_api_client/cli/grp_enforcements/grp_tasks/export_get_filters.py
+++ b/axonius_api_client/cli/grp_enforcements/grp_tasks/export_get_filters.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-from axonius_api_client.api.json_api.tasks.task_filters import (
-    TaskFilters,
-    ATTR_MAP,
-)
-from axonius_api_client.tools import json_dump, path_write
+from ....api.json_api.tasks.task_filters import TaskFilters, ATTR_MAP
+from ....tools import json_dump, path_write
 from ...context import click
 
 

--- a/axonius_api_client/cli/grp_enforcements/grp_tasks/options_get.py
+++ b/axonius_api_client/cli/grp_enforcements/grp_tasks/options_get.py
@@ -2,10 +2,10 @@
 """Common options for the "enforcements tasks" group of commands."""
 import click
 
-from axonius_api_client.api.json_api.count_operator import OperatorTypes
-from axonius_api_client.api.json_api.paging_state import PagingState
-from axonius_api_client.constants.api import RE_PREFIX
-from axonius_api_client.constants.general import SPLITTER
+from ....api.json_api.count_operator import OperatorTypes
+from ....api.json_api.paging_state import PagingState
+from ....constants.api import RE_PREFIX
+from ....constants.general import SPLITTER
 from .export_get import DEFAULT_EXPORT_FORMAT, EXPORT_FORMATS
 
 from ...options import AUTH, OPT_EXPORT_FILE, OPT_EXPORT_OVERWRITE

--- a/axonius_api_client/cli/grp_enforcements/grp_tasks/options_get_filters.py
+++ b/axonius_api_client/cli/grp_enforcements/grp_tasks/options_get_filters.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
-from axonius_api_client.api.json_api.tasks.task_filters import (
-    build_include_options,
-)
+from ....api.json_api.tasks.task_filters import build_include_options
 from ...context import click
 from ...options import AUTH, OPT_EXPORT_FILE, OPT_EXPORT_OVERWRITE
 from .export_get_filters import EXPORT_FORMATS, DEFAULT_EXPORT_FORMAT

--- a/axonius_api_client/cli/grp_tools/cmd_signup.py
+++ b/axonius_api_client/cli/grp_tools/cmd_signup.py
@@ -2,7 +2,6 @@
 """Command line interface for Axonius API Client."""
 import click
 
-from ...api import Signup
 from ..options import add_options
 from .grp_common import EXPORT_FORMATS
 from .grp_options import OPT_ENV, OPT_EXPORT
@@ -60,12 +59,11 @@ OPTIONS = [URL, PASSWORD, COMPANY, CONTACT, OPT_EXPORT, OPT_ENV]
 @click.pass_context
 def cmd(ctx, url, password, company_name, contact_email, export_format, env):
     """Perform the initial signup to an instance."""
-    entry = Signup(url=url)
+    client = ctx.obj.create_client(url=url)
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        data = entry.signup(
+        data = client.signup.signup(
             password=password, company_name=company_name, contact_email=contact_email
         )
-
-    click.secho(EXPORT_FORMATS[export_format](data=data, signup=True, env=env, url=entry.http.url))
+    click.secho(EXPORT_FORMATS[export_format](data=data, signup=True, env=env, url=client.http.url))
     ctx.obj.echo_ok("Signup completed successfully!")
     ctx.exit(0)

--- a/axonius_api_client/cli/grp_tools/cmd_system_status.py
+++ b/axonius_api_client/cli/grp_tools/cmd_system_status.py
@@ -5,7 +5,6 @@ import time
 
 import click
 
-from ...api import Signup
 from ...tools import dt_now
 from ..context import CONTEXT_SETTINGS
 from ..options import URL, add_options
@@ -52,26 +51,27 @@ def cmd(ctx, url, wait, sleep, max_wait):
     def get_status():
         """Get the system status safely."""
         try:
-            data = entry.system_status
-            message = data.msg
-            status_code = data.status_code
-            is_ready = data.is_ready
+            data = client.signup.system_status
+            _message = data.msg
+            _status_code = data.status_code
+            _is_ready = data.is_ready
         except Exception as exc:
-            message = f"HTTP Error: {exc}"
-            status_code = 1000
-            is_ready = False
+            _message = f"HTTP Error: {exc}"
+            _status_code = 1000
+            _is_ready = False
 
         msg = [
-            f"URL: {entry.http.url}",
+            f"URL: {client.signup.http.url}",
             f"Date: {dt_now()}",
-            f"Message: {message}",
-            f"Status Code: {status_code}",
-            f"Ready: {is_ready}",
+            f"Message: {_message}",
+            f"Status Code: {_status_code}",
+            f"Ready: {_is_ready}",
         ]
         click.secho("\n".join(msg))
-        return is_ready, status_code
+        return _is_ready, _status_code
 
-    entry = Signup(url=url)
+    client = ctx.obj.create_client(url=url)
+
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
         is_ready, status_code = get_status()
 

--- a/axonius_api_client/cli/grp_tools/cmd_use_token_reset_token.py
+++ b/axonius_api_client/cli/grp_tools/cmd_use_token_reset_token.py
@@ -2,7 +2,6 @@
 """Command line interface for Axonius API Client."""
 import click
 
-from ...api import Signup
 from ..context import CONTEXT_SETTINGS
 from ..options import URL, add_options
 
@@ -36,8 +35,8 @@ OPTIONS = [URL, TOKEN, PASSWORD]
 @click.pass_context
 def cmd(ctx, url, token, password):
     """Use a password reset token."""
-    client = Signup(url=url)
+    client = ctx.obj.create_client(url=url)
     with ctx.obj.exc_wrap(wraperror=ctx.obj.wraperror):
-        name = client.use_password_reset_token(token=token, password=password)
+        name = client.signup.use_password_reset_token(token=token, password=password)
 
     ctx.obj.echo_ok(f"Password successfully reset for user {name!r}")

--- a/axonius_api_client/cli/helps.py
+++ b/axonius_api_client/cli/helps.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Command line interface for Axonius API Client."""
 from ..constants.wizards import Docs
-from ..constants.asset_helpers import ASSETS_HELPERS
 
 HELPSTR_AUTH = """
 Detailed help for authentication:
@@ -219,12 +218,21 @@ Tips:
     - node key now needs to be 'node_name'
 """
 
-HELPSTRS = {}
-HELPSTRS["auth"] = HELPSTR_AUTH
-HELPSTRS["assetexport"] = HELPSTR_EXPORT_ASSET
-HELPSTRS["selectfields"] = HELPSTR_SELECT_FIELDS
-HELPSTRS["query"] = HELPSTR_QUERY
-HELPSTRS["wizard"] = Docs.TEXT
-HELPSTRS["wizard_csv"] = Docs.CSV
-HELPSTRS["multiple_cnx_json"] = HELPSTR_MULTI_CNX_JSON
-HELPSTRS["asset_helper"] = ASSETS_HELPERS.to_str()
+
+def asset_helper(**kwargs) -> str:
+    """Return the help string for the asset helpers"""
+    from ..constants.asset_helpers import ASSETS_HELPERS
+
+    return ASSETS_HELPERS.to_str()
+
+
+HELPSTRS = {
+    "auth": HELPSTR_AUTH,
+    "assetexport": HELPSTR_EXPORT_ASSET,
+    "selectfields": HELPSTR_SELECT_FIELDS,
+    "query": HELPSTR_QUERY,
+    "wizard": Docs.TEXT,
+    "wizard_csv": Docs.CSV,
+    "multiple_cnx_json": HELPSTR_MULTI_CNX_JSON,
+    "asset_helper": asset_helper,
+}

--- a/axonius_api_client/cli/options.py
+++ b/axonius_api_client/cli/options.py
@@ -7,7 +7,6 @@ from .. import DEFAULT_PATH
 from ..constants.api import MAX_PAGE_SIZE, TABLE_FORMAT
 from ..tools import coerce_int
 from . import context
-from .helps import HELPSTRS
 
 
 def build_filter_opt(value_type: str):
@@ -46,7 +45,11 @@ def int_callback(ctx, param, value):
 def help_callback(ctx, param, value):
     """Pass."""
     if value:
+        from .helps import HELPSTRS
+
         helpstr = HELPSTRS[value]
+        if callable(helpstr):
+            helpstr = helpstr(ctx=ctx, param=param, value=value)
         click.secho(helpstr, err=True, fg="blue")
         ctx.exit(0)
 

--- a/axonius_api_client/constants/asset_helpers.py
+++ b/axonius_api_client/constants/asset_helpers.py
@@ -3,7 +3,6 @@ import dataclasses
 import typing as t
 
 from ..data import BaseData
-from ..tools import json_dump, listify
 
 
 def to_json_api(value: t.Any, schema: str) -> dict:
@@ -36,6 +35,8 @@ class AssetsHelper(BaseData):
     @staticmethod
     def join_path(values: t.List[str]) -> str:
         """Join a list of strings with ' => '"""
+        from axonius_api_client.tools import listify
+
         return " => ".join(listify(values))
 
     @property
@@ -61,6 +62,8 @@ class AssetsHelper(BaseData):
 
     def to_str(self) -> str:
         """Return a string describing this helper."""
+        from axonius_api_client.tools import json_dump
+
         value: str = f"""
 ## {self.name}
 

--- a/axonius_api_client/parsers/wizards.py
+++ b/axonius_api_client/parsers/wizards.py
@@ -18,7 +18,7 @@ from ..tools import (
     parse_ip_network,
     strip_right,
 )
-from .tables import tablize, tablize_sqs
+from .tables import tablize
 
 CACHE_MAXSIZE: int = 4096
 CACHE_TTL: int = 30
@@ -411,7 +411,9 @@ class WizardParser:
 
     def enum_cb_sq(self, value: Any) -> str:
         """Pass."""
-        data = self.get_sqs()
+        from ..api.json_api.saved_queries import SavedQuery
+
+        data: List[SavedQuery] = self.get_sqs()
         value_check = lowish(value)
 
         for item in data:
@@ -419,7 +421,8 @@ class WizardParser:
                 return item.uuid
 
         err = f"No Saved Query found with name or UUID of {value!r} out of {len(data)} items"
-        err_table = tablize_sqs(data=data, err=err)
+        err_table = tablize(value=[x.to_tablize() for x in data], err=err)
+        # err_table = tablize_sqs(data=data, err=err)
         raise WizardError(err_table)
 
     def enum_cb_cnx_label(self, value: Any) -> str:

--- a/axonius_api_client/tests/conftest.py
+++ b/axonius_api_client/tests/conftest.py
@@ -15,7 +15,6 @@ from .utils import (
     get_arg_key,
     get_arg_secret,
     get_arg_url,
-    get_http,
     get_connect,
     get_arg_cf_token,
     get_arg_cf_error,
@@ -255,13 +254,8 @@ def api_settings_ip(api_client):
 @pytest.fixture(scope="session")
 def api_signup(request):
     """Test utility."""
-    from axonius_api_client.api import Signup
-    from axonius_api_client.auth import AuthNull
-
-    http = get_http(request)
-    auth = AuthNull(http=http)
-    obj = Signup(auth=auth)
-    return obj
+    client = get_connect(request=request)
+    return client.signup
 
 
 @pytest.fixture(scope="session")

--- a/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
+++ b/axonius_api_client/tests/tests_api/tests_adapters/test_cnx.py
@@ -308,8 +308,10 @@ class TestCnxPublic(TestCnxBase):
 
     def test_get_by_label(self, apiobj):
         cnx = get_cnx_existing(apiobj)
+        # 2023/04/03 - connection_label not returned in config any longer?
+        label = cnx["config"].get("connection_label") or cnx.get("connection_label") or ""
         found = apiobj.cnx.get_by_label(
-            value=cnx["config"].get("connection_label") or "",
+            value=label,
             adapter_name=cnx["adapter_name"],
             adapter_node=cnx["node_name"],
         )

--- a/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
+++ b/axonius_api_client/tests/tests_api/tests_assets/test_saved_query.py
@@ -1095,7 +1095,18 @@ def validate_sq(asset):
     folder_id = query.pop("folder_id", None)
     assert folder_id is None or isinstance(folder_id, str)
 
+    # 2023/04/02: {'enforcementFilter': None, 'uniqueAdapters': False}
+    enforcement_filter = query.pop("enforcementFilter", None)
+    assert isinstance(enforcement_filter, str) or enforcement_filter is None
+
+    unique_adapters = query.pop("uniqueAdapters", None)
+    assert isinstance(unique_adapters, bool) or unique_adapters is None
+
     assert not query, list(query)
+
+    # 2023/04/02: {'colExcludeAdapters': []}
+    col_exclude_adapters = view.pop("colExcludeAdapters", [])
+    assert isinstance(col_exclude_adapters, list) or col_exclude_adapters is None
     assert not view, list(view)
 
     document_meta = asset.pop("document_meta", {})

--- a/axonius_api_client/tests/tests_api/tests_system/test_data_scopes.py
+++ b/axonius_api_client/tests/tests_api/tests_system/test_data_scopes.py
@@ -69,6 +69,8 @@ class DataScopeFixtures:
         self.cleanup_data_scopes(apiobj=apiobj, value=row.uuid)
 
     def create_asset_scope(self, apiasset, name):
+        if not apiasset.data_scopes.is_feature_enabled:
+            pytest.skip("Data Scopes Feature Flag not enabled")
         self.cleanup_asset_scopes(apiasset=apiasset, value=name)
 
         row = apiasset.saved_query.add(

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -2447,7 +2447,10 @@ def get_diff_seconds(
     seconds: t.Optional[float] = None
     if start is not None:
         start: datetime.datetime = dt_parse(obj=start)
-        stop: datetime.datetime = dt_now if stop is None else dt_parse(stop)
+        if stop is None:
+            stop = dt_now()
+        else:
+            stop = dt_parse(stop)
         delta: datetime.timedelta = stop - start
         seconds: float = delta.total_seconds()
         if isinstance(places, int):

--- a/axonius_api_client/tools.py
+++ b/axonius_api_client/tools.py
@@ -33,8 +33,8 @@ from .constants.ctypes import (
     PatternLike,
     PatternLikeListy,
     TypeDate,
-    TypeFloat,
     TypeDelta,
+    TypeFloat,
 )
 from .constants.general import (
     DAYS_MAP,
@@ -46,6 +46,7 @@ from .constants.general import (
     FILE_DATE_FMT,
     HUMAN_SIZES,
     NO,
+    NO_STR,
     OK_ARGS,
     OK_TMPL,
     SECHO_ARGS,
@@ -57,7 +58,6 @@ from .constants.general import (
     WARN_TMPL,
     YES,
     YES_STR,
-    NO_STR,
 )
 from .constants.logs import MAX_BODY_LEN
 from .exceptions import FormatError, ToolsError
@@ -1546,18 +1546,19 @@ def bom_strip(content: t.Union[str, bytes], strip=True, bom: bytes = codecs.BOM_
         content: string to remove BOM marker from if found
         strip: remove whitespace before & after removing BOM marker
     """
-    content = content.strip() if strip else content
+    if isinstance(content, (str, bytes)):
+        content = content.strip() if strip else content
 
-    if isinstance(bom, bytes) and isinstance(content, str):
-        bom = bom.decode()
-    elif isinstance(bom, str) and isinstance(content, bytes):
-        bom = bom.encode()
+        if isinstance(bom, bytes) and isinstance(content, str):
+            bom = bom.decode()
+        elif isinstance(bom, str) and isinstance(content, bytes):
+            bom = bom.encode()
 
-    bom_len = len(bom)
-    if content.startswith(bom):
-        content = content[bom_len:]
+        bom_len = len(bom)
+        if content.startswith(bom):
+            content = content[bom_len:]
 
-    content = content.strip() if strip else content
+        content = content.strip() if strip else content
     return content
 
 


### PR DESCRIPTION
# 5.0.1

<!-- TOC -->
* [5.0.1](#501)
  * [Axonshell changes](#axonshell-changes)
    * [FEATURE expose include field when adding or removing tags](#feature-expose-include-field-when-adding-or-removing-tags)
  * [Library changes](#library-changes)
    * [FEATURE expose include field when adding or removing tags](#feature-expose-include-field-when-adding-or-removing-tags-1)
    * [FEATURE expose column filter arguments for `client.{asset_type}.saved_query.add`](#feature-expose-column-filter-arguments-for-clientassettypesavedqueryadd)
    * [FIX schemas](#fix-schemas)
    * [FIX tools.get_diff_seconds TypeError](#fix-toolsgetdiffseconds-typeerror)
    * [FIX None.strip errors](#fix-nonestrip-errors)
    * [FIX Signup not being implemented properly](#fix-signup-not-being-implemented-properly)
    * [FIX Circular import reference](#fix-circular-import-reference)
    * [FIX tests](#fix-tests)
<!-- TOC -->

## Axonshell changes

### FEATURE expose include field when adding or removing tags

Added two new options to all `axonshell {asset_type} devices get*` commands:

```text
  --tag-invert / --no-tag-invert  Only add tags to assets that do NOT match
                                  the query provided  [env var:
                                  AX_TAGS_ADD_INVERT_SELECTION; default: no-
                                  tag-invert]
  --untag-invert / --no-untag-invert
                                  Only remove tags from assets that do NOT
                                  match the query provided  [env var:
                                  AX_TAGS_REMOVE_INVERT_SELECTION; default:
                                  no-untag-invert]
```

These options allow you to add tags to or remove tags from assets that do not match a query.
For example, to add the tag `is_not_windows` to all assets that are not Windows devices:

```bash
axonshell devices get --wiz simple "os.type equals windows" --tag-invert --tag is_not_windows
```

Conversely, you can remove a tag from all assets that do not match a query:

```bash
axonshell devices get --wiz simple "os.type equals windows" --untag-invert --untag is_not_windows
```

## Library changes

### FEATURE expose include field when adding or removing tags

* Added `client.{asset_type}.tags` as a shortcut to `client.{asset_type}.labels`
* Added `invert_selection` argument to `client.{asset_type}.tags.add`:
```text
invert_selection: bool = False
True=add tags to assets that ARE NOT supplied in rows;
False=add tags to assets that ARE supplied in rows
```
* Added `invert_selection` argument to `client.{asset_type}.tags.remove`:
```text
invert_selection: bool = False
True=remove tags from assets that ARE NOT supplied in rows;
False=remove tags from assets that ARE supplied in rows
```
* Added `include` argument to `client.{asset_type}.tags.add`:
```text
include: bool = True
True=include assets that match query;
False=exclude assets that match query
```
* Added `include` argument to `client.{asset_type}.tags.remove`:
```text
include: bool = True
True=include assets that match query;
False=exclude assets that match query
```

### FEATURE expose column filter arguments for `client.{asset_type}.saved_query.add`

* fixed a minor bug where the `meta` key in the saved query was not getting defined correctly
* Added arguments to `client.{asset_type}.saved_query.build_add_model`:
```text
field_filters: t.Optional[t.List[dict]] = None,
excluded_adapters: t.Optional[t.List[dict]] = None,
asset_excluded_adapters: t.Optional[t.List[dict]] = None,
asset_filters: t.Optional[t.List[dict]] = None,
```
```text
field_filters: field filters to apply to this query
excluded_adapters: adapters to exclude from this query
asset_excluded_adapters: adapters to exclude from this query
asset_filters: asset filters to apply to this query
```

### FIX schemas

* Fixed `json_api.assets.asset_id_response.AssetGetByIdSchema` to correctly define `labels` 
  field as List[str] instead of List[dict] (REST API defines it improperly as List[dict])
* Fixed `json_api.assets.asset_id_response.AssetGetById` to correctly define `labels` field as 
  List[str] instead of List[dict] (REST API defines it improperly as List[dict])
* Added new fields in `json_api.adapters.adapter_node.AdapterNodeCnx`:
```text 
last_successful_fetch: t.Optional[datetime.datetime] 
latest_configuration_change: t.Optional[datetime.datetime] 
```
axonius_api_client/api/json_api/adapters/fetch_history_response.py
* Added new fields in `json_api.adapters.fetch_history_response.AdapterFetchHistorySchema`:
```text
has_configuration_changed = SchemaBool(
    description="Shows if the configuration changed since last fetch",
    load_default=False,
    dump_default=False,
)
last_fetch_time = SchemaDatetime(
    description="The last fetch time",
    allow_none=True,
    load_default=None,
    dump_default=None,
)
```
* Added new fields in `json_api.adapters.fetch_history_response.AdapterFetchHistory`:
```text
has_configuration_changed: bool
last_fetch_time: t.Optional[datetime.datetime]
```

### FIX tools.get_diff_seconds TypeError

* Error:
```text
TypeError: unsupported operand type(s) for -: 'function' and 'datetime.datetime'
```
* Fixed typo where dt_now was not called as a function when a None value was supplied

### FIX None.strip errors

* Found a few potential errors with `strip` usage and fixed them 

### FIX Signup not being implemented properly

* Fixed a bug where the `signup` method was not implemented properly 

### FIX Circular import reference

* Fixed a circular import reference introduced in 5.0.0

### FIX tests

- test fix for when data scopes are not enabled
- test fix for adapter connection label no longer being returned in adapter connection configuration
- lint fixes
- fixed a number of possible bugs with `strip` usage against strings
