### PR TITLE
5.0.3

### DIFF
--- a/axonius_api_client/connect.py
+++ b/axonius_api_client/connect.py
@@ -672,9 +672,12 @@ log_body_lines = 10000
         return self.AUTH.get_api_keys()
 
     @property
-    def current_user(self) -> api.json_api.account.CurrentUser:
-        """Get the current user."""
-        return self.AUTH.get_current_user()
+    def current_user(self) -> t.Optional[api.json_api.account.CurrentUser]:
+        """Get the current user (returns 404 for service accounts)."""
+        try:
+            return self.AUTH.get_current_user()
+        except Exception:
+            return None
 
     @property
     def about(self):
@@ -714,7 +717,8 @@ log_body_lines = 10000
         """Get the Axonius instance user for use in str."""
         value = "User: ??"
         if self.STARTED:
-            value = self.current_user.str_connect
+            if self.current_user:
+                value = self.current_user.str_connect
         return value
 
     @property

--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "5.0.2"
+__version__ = "5.0.3"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
# 5.0.3

<!-- TOC -->
* [5.0.3](#503)
  * [Library changes](#library-changes)
    * [FIX wrap errors when getting current user](#fix-wrap-errors-when-getting-current-user-)
<!-- TOC -->

## Library changes

### FIX wrap errors when getting current user 

While using a service account to authenticate with axonshell,
the `get_current_user` method returns a 404 error.

This is now fixed by wrapping the call and returning None if the
call fails for any reason.
