### PR TITLE
5.0.3

### DIFF
--- a/axonius_api_client/version.py
+++ b/axonius_api_client/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Version information for this package."""
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 VERSION: str = __version__
 """Version of package."""
 


### PR DESCRIPTION
# 5.0.3

<!-- TOC -->
* [5.0.3](#503)
  * [Library changes](#library-changes)
    * [FIX wrap errors when getting current user](#fix-wrap-errors-when-getting-current-user-)
<!-- TOC -->

## Library changes

### FIX wrap errors when getting current user 

While using a service account to authenticate with axonshell,
the `get_current_user` method returns a 404 error.

This is now fixed by wrapping the call and returning None if the
call fails for any reason.
