### PR TITLE
[SA-4690] Allow complex objects in system settings to be configured

### DIFF
--- a/axonius_api_client/parsers/config.py
+++ b/axonius_api_client/parsers/config.py
@@ -165,7 +165,7 @@ def config_check_int(
 
 
 def config_check_array(
-    value: Union[str, List[str]],
+    value: Union[str, List[Any]],
     schema: dict,
     source: str,
     callbacks: Optional[dict] = None,
@@ -186,7 +186,7 @@ def config_check_array(
 
     is_list = isinstance(value, list)
 
-    if not is_list or (is_list and not all([isinstance(x, str) for x in value])):
+    if not is_list:
         sinfo = config_info(schema=schema, value=value, source=source)
         msg = f"{sinfo}\nIs not a list of strings or a comma seperated string!"
         raise ConfigInvalidValue(msg)


### PR DESCRIPTION
This change is specifically related to axonshell to configure custom enrichment stmts. This will allow for the following command.
`axonshell system settings-global update-sub-section-from-json -se static_analysis_settings -sb enrichment_settings -if enrichment.json`
considering this enrichment.json
```
{
  "enabled": true,
  "enrichment_rules": [
    {
      "adapter": null,
      "conditional": "upload",
      "upload": {
        "enrichment_input": {
          "filename": "my_enrichment.csv",
          "uuid": "64c196defc669960c6b98c2e"
        },
        "enrichment_query": "enrich 'devices' with (*) on (device.specific_data.data.hostname contains source.prefix)"
      }
    }
  ]
}
```

you can get the existing enrichment file with this command

`axonshell system settings-global get-sub-section -se static_analysis_settings -sb enrichment_settings --export-format json-config` 

and you can make changes to that json accordingly