### PR TITLE
[SA-5486] JSONDecodeError with Enforcement Sets

### DIFF
--- a/axonius_api_client/api/json_api/enforcements.py
+++ b/axonius_api_client/api/json_api/enforcements.py
@@ -300,6 +300,9 @@ class EnforcementBasicSchema(BaseSchemaJson):
     @marshmallow.pre_load
     def pre_load_fix(self, data, **kwargs):
         """Pass."""
+        # PBUG : Updated by is now coming back as an empty string sometimes.
+        if data.get('updated_by') is "":
+            data['updated_by'] = "{}"
         return {k.replace(".", "_"): v for k, v in data.items()}
 
 


### PR DESCRIPTION
This fixes an issue caused by the `updated_by` param coming back as an empty string.