### PR TITLE
bugfix/AX-62610_short_axon_id_appears_in_exported_get

### DIFF
--- a/axonius_api_client/api/asset_callbacks/base.py
+++ b/axonius_api_client/api/asset_callbacks/base.py
@@ -16,6 +16,7 @@ from ...constants.fields import (
     FIELDS_ENTITY_PASSTHRU,
     SCHEMAS_CUSTOM,
     EXCLUDED_DEFAULT_FIELDS_MAP,
+    ALL_FIELDS_KEY,
 )
 from ...exceptions import ApiError
 from ...tools import (
@@ -286,6 +287,9 @@ class Base:
             self.set_arg_value("field_excludes", value=excludes + missing)
 
         fields = listify(self.STORE.get("fields", []))
+        should_not_exclude_fields = ALL_FIELDS_KEY in fields
+        if should_not_exclude_fields:
+            return
         default_fields_to_exclude = [field[1] for field in EXCLUDED_DEFAULT_FIELDS_MAP if field[0] not in fields]
         if default_fields_to_exclude:
             self.set_arg_value("field_excludes", value=excludes + default_fields_to_exclude)

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -103,6 +103,16 @@ FIELDS_DETAILS_EXCLUDE: t.List[str] = [
 ]
 """Fields that should be excluded when include_details=True"""
 
+EXCLUDED_DEFAULT_FIELDS_MAP: t.List[tuple] = [
+    ("agg:axon_id", "internal_axon_id"),
+    ("agg:adapters", "adapters"),
+    ("agg:labels", "labels"),
+    ("agg:adapter_list_length", "adapter_list_length"),
+    ("agg:short_axon_id", "short_axon_id"),
+    ("agg:axon_id", "specific_data.data.axon_id"),
+]
+"""Fields that are manually excluded unless specifically requested"""
+
 FIELDS_ENTITY_PASSTHRU: t.List[str] = [
     "adapter_list_length",
     "internal_axon_id",

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -104,10 +104,6 @@ FIELDS_DETAILS_EXCLUDE: t.List[str] = [
 """Fields that should be excluded when include_details=True"""
 
 EXCLUDED_DEFAULT_FIELDS_MAP: t.List[tuple] = [
-    ("agg:axon_id", "internal_axon_id"),
-    ("agg:adapters", "adapters"),
-    ("agg:labels", "labels"),
-    ("agg:adapter_list_length", "adapter_list_length"),
     ("agg:short_axon_id", "short_axon_id"),
     ("agg:axon_id", "specific_data.data.axon_id"),
 ]

--- a/axonius_api_client/constants/fields.py
+++ b/axonius_api_client/constants/fields.py
@@ -109,6 +109,9 @@ EXCLUDED_DEFAULT_FIELDS_MAP: t.List[tuple] = [
 ]
 """Fields that are manually excluded unless specifically requested"""
 
+ALL_FIELDS_KEY: str = "agg:all"
+"""Field that's being used to retrieve all fields from entities"""
+
 FIELDS_ENTITY_PASSTHRU: t.List[str] = [
     "adapter_list_length",
     "internal_axon_id",


### PR DESCRIPTION
https://axonius.atlassian.net/browse/AX-62610
1. A regular request, with hostname as the requested field:
```
ax.axonius_sdk.client.devices.get(query='',
                                  fields=['agg:hostname'],
                                  fields_default=0,
                                  field_excludes=[],
                                  export='json',
                                  export_file='stuff/hostname.json',
                                  export_path='',
                                  explode_entities=False,
                                  connect_timeout=20,
                                  response_timeout=60,
                                  export_overwrite=True
                                  )
```
[hostname.json](https://github.com/user-attachments/files/18559250/hostname.json)

2. A request containing all fields that are hidden by default:
```
ax.axonius_sdk.client.devices.get(query='',
                                  fields=["agg:axon_id","agg:adapters","agg:labels","agg:adapter_list_length","agg:short_axon_id","agg:axon_id"],
                                  fields_default=0,
                                  field_excludes=[],
                                  export='json',
                                  export_file='stuff/551.json',
                                  export_path='',
                                  explode_entities=False,
                                  connect_timeout=20,
                                  response_timeout=60,
                                  export_overwrite=True
                                  )
```
[with_excluded_fields.json](https://github.com/user-attachments/files/18557742/with_excluded_fields.json)

